### PR TITLE
Bugfix for switching to plug-in window inside FX chain

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1179,12 +1179,14 @@ bool maybeSwitchToFxPluginWindow() {
 	char name[8];
 	if (GetWindowText(window, name, sizeof(name)) == 0)
 		return false;
-	if (strncmp(name, "FX: ", 4) != 0 &&
+	if (strncmp(name, "FX: ", 4) != 0 && // FX chain window
+		// floating FX window, for different plug-in types
 		strncmp(name, "DX: ", 4) != 0 &&
 		strncmp(name, "VST: ", 5) != 0 &&
 		strncmp(name, "VSTi: ", 6) != 0 &&
 		strncmp(name, "VST3: ", 6) != 0 &&
-		strncmp(name, "VST3i: ", 7) != 0) {
+		strncmp(name, "VST3i: ", 7) != 0
+	) {
 		return false;
 	}
 	// Descend.

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1176,11 +1176,17 @@ void clickIoButton(MediaTrack* track, bool rightClick=false) {
 
 bool maybeSwitchToFxPluginWindow() {
 	HWND window = GetForegroundWindow();
-	char name[4];
+	char name[8];
 	if (GetWindowText(window, name, sizeof(name)) == 0)
 		return false;
-	if (strncmp(name, "FX: ", 4) != 0)
+	if (strncmp(name, "FX: ", 4) != 0 &&
+		strncmp(name, "DX: ", 4) != 0 &&
+		strncmp(name, "VST: ", 5) != 0 &&
+		strncmp(name, "VSTi: ", 6) != 0 &&
+		strncmp(name, "VST3: ", 6) != 0 &&
+		strncmp(name, "VST3i: ", 7) != 0) {
 		return false;
+	}
 	// Descend.
 	if (!(window = GetWindow(window, GW_CHILD)))
 		return false;
@@ -1193,10 +1199,7 @@ bool maybeSwitchToFxPluginWindow() {
 	// This should get the plugin window.
 	if (!(window = GetWindow(window, GW_HWNDLAST)))
 		return false;
-	HWND oldFocus = GetFocus();
 	SetFocus(window);
-	if (GetFocus() == oldFocus) // Focus didn't move
-		return false;
 	return true;
 }
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1195,12 +1195,17 @@ bool maybeSwitchToFxPluginWindow() {
 	// This is a property page containing the plugin window among other things.
 	if (!(window = GetWindow(window, GW_HWNDLAST)))
 		return false;
+	HWND dialog = window;
 	// Descend.
 	if (!(window = GetWindow(window, GW_CHILD)))
 		return false;
 	// This should get the plugin window.
 	if (!(window = GetWindow(window, GW_HWNDLAST)))
 		return false;
+	// set property page name, to avoid CPU label audition after switching
+	if (GetWindowText(dialog, name, sizeof(name)) == 0) {
+		SetWindowText(dialog, " ");
+	}
 	// Try to focus the first child in Z order
 	HWND plugin = window; // remember plug-in window
 	HWND child;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1201,7 +1201,19 @@ bool maybeSwitchToFxPluginWindow() {
 	// This should get the plugin window.
 	if (!(window = GetWindow(window, GW_HWNDLAST)))
 		return false;
-	SetFocus(window);
+	// Try to focus the first child in Z order
+	HWND plugin = window; // remember plug-in window
+	HWND child;
+	while ((child = GetWindow(window, GW_CHILD))) {
+		window = child;
+	}
+	while (window) {
+		SetFocus(window);
+		if ((window == plugin) || (GetFocus() == window)) {
+			break; // success or the last possible attempt
+		}
+		window = GetParent(window);
+	}
 	return true;
 }
 


### PR DESCRIPTION
Extended to float FX windows.

I have quite some thoughts about it.

Originally it was one character bugfix, 4 characters buffer was insufficient for "FX: " string including ending zero. So F6 could not work.

But I have extended to support floating FX windows. May be not so important before, Sibiac is working with screen images. And there are big plug-ins like AD2 which have hard time to fit into screen, especially at lower resolutions and when wrapped inside FX chain.

Finally, once F6 has started to work, I was confused that in case plug-in is already in focus, F6 start switching Solo. Not accessible plug-ins and in some cases Sibiac enabled plug-ins  produce no special audition. So people probably will try to press F6 more then once, and then get Solo switch. I have removed the focus change check and always consume F6. Since that is after FX check, I can not imagine the situation when it is unexpectedly consumed.

But... It can be practical to solo/unsolo the track when operating FXes. And default key for that is F6. So I propose to find better key for the focusing operation. I am not experienced to propose concrete  key, you know that better.