### PR TITLE
Stop using hookpostcommand in favor of executing post commands from our own command handlers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -532,3 +532,4 @@ The resulting installer can be found in the installer directory.
 - Garth Humphreys
 - Lars Sönnebo
 - Alexey Zhelezov
+- Leonard de Ruijter

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -455,8 +455,11 @@ void postToggleTrackFxBypass(int command) {
 	postToggleTrackFxBypass(track);
 }
 
-bool shouldReportScrub = true;
+void postToggleMasterTrackFxBypass(int command) {
+	postToggleTrackFxBypass(GetMasterTrack(0));
+}
 
+bool shouldReportScrub = true;
 void postCursorMovement(int command) {
 	fakeFocus = FOCUS_RULER;
 	outputMessage(formatCursorPosition().c_str());
@@ -883,6 +886,7 @@ PostCommand POST_COMMANDS[] = {
 	{40495, postCycleTrackMonitor}, // Track: Cycle track record monitor
 	{40282, postInvertTrackPhase}, // Track: Invert track phase
 	{40298, postToggleTrackFxBypass}, // Track: Toggle FX bypass for current track
+	{16, postToggleMasterTrackFxBypass}, // Track: Toggle FX bypass for master track
 	{40344, postToggleTrackFxBypass}, // Track: toggle FX bypass on all tracks
 	{40104, postCursorMovementScrub}, // View: Move cursor left one pixel
 	{40105, postCursorMovementScrub}, // View: Move cursor right one pixel
@@ -1604,12 +1608,6 @@ void cmdMoveItems(Command* command) {
 		reportActionName(command->gaccel.accel.cmd);
 }
 
-void cmdToggleMasterTrackFxBypass(Command* command) {
-	// #42: This really should be a post command, but hookpostcommand doesn't fire.
-	Main_OnCommand(command->gaccel.accel.cmd, 0);
-	postToggleTrackFxBypass(GetMasterTrack(0));
-}
-
 void cmdDeleteMarker(Command* command) {
 	int count = CountProjectMarkers(0, NULL, NULL);
 	Main_OnCommand(40613, 0); // Markers: Delete marker near cursor
@@ -2050,7 +2048,6 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40226}, NULL}, NULL, cmdMoveItems}, // Item edit: Shrink left edge of items
 	{MAIN_SECTION, {{0, 0, 40227}, NULL}, NULL, cmdMoveItems}, // Item edit: Shrink right edge of items
 	{MAIN_SECTION, {{0, 0, 40228}, NULL}, NULL, cmdMoveItems}, // Item edit: Grow right edge of items
-	{MAIN_SECTION, {{0, 0, 16}, NULL}, NULL, cmdToggleMasterTrackFxBypass}, // Track: Toggle FX bypass for master track
 	{MAIN_SECTION, {{0, 0, 40613}, NULL}, NULL, cmdDeleteMarker}, // Markers: Delete marker near cursor
 	{MAIN_SECTION, {{0, 0, 40615}, NULL}, NULL, cmdDeleteRegion}, // Markers: Delete region near cursor
 	{MAIN_SECTION, {{0, 0, 40617}, NULL}, NULL, cmdDeleteTimeSig}, // Markers: Delete time signature marker near cursor

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -460,6 +460,7 @@ void postToggleMasterTrackFxBypass(int command) {
 }
 
 bool shouldReportScrub = true;
+
 void postCursorMovement(int command) {
 	fakeFocus = FOCUS_RULER;
 	outputMessage(formatCursorPosition().c_str());


### PR DESCRIPTION
This idea was introduced by @jcsteh in https://github.com/jcsteh/osara/issues/193#issuecomment-479233107

This implements the described behavior. I'm executing handlePostCommand from both handleCommand and handleMainCommandFallback, as if I understand the comments correctly, only handleMainCommandFallback (i.e. hookcommand) is executed for user defined actions (#29).

I also reverted https://github.com/jcsteh/osara/commit/456768afb8f6a9317e7b1f68f4bb9bf229b857e9 and made sure that fx bypass is still reported for the master track after this, which it is.