### PR TITLE
Only use post actions for the main section

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2242,9 +2242,8 @@ bool handleCommand(KbdSectionInfo* section, int command, int val, int valHw, int
 	} else if (isShortcutHelpEnabled) {
 		reportActionName(command, section, false);
 		return true;
-	}
-	// For now, only support the main section for post commands.
-	else if ((section->uniqueID == MAIN_SECTION) && handlePostCommand(command)) {
+	} else if ((section->uniqueID == MAIN_SECTION) && handlePostCommand(command)) {
+		// For now, only support the main section for post commands.
 		return true;
 	}
 	return false;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2242,8 +2242,11 @@ bool handleCommand(KbdSectionInfo* section, int command, int val, int valHw, int
 	} else if (isShortcutHelpEnabled) {
 		reportActionName(command, section, false);
 		return true;
-	} else if (handlePostCommand(command))
+	}
+	// For now, only support the main section for post commands.
+	else if ((section->uniqueID == MAIN_SECTION) && handlePostCommand(command)) {
 		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
#194 introduced an issue where activating a folder or item in the media explorer started recording instead. This was because the action ID for that action and the record action is equal. As there is a post command registered for record, that command was executed instead.

This again limits post commands to the main section. Fixes #199