### PR TITLE
Fix reporting of volume and pan when automating

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -134,6 +134,7 @@
 #define REAPERAPI_WANT_EnumProjects
 #define REAPERAPI_WANT_GetProjectName
 #define REAPERAPI_WANT_plugin_register
+#define REAPERAPI_WANT_GetTrackUIVolPan
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -574,9 +574,12 @@ void postGoToSpecificMarker(int command) {
 }
 
 void postChangeTrackVolume(MediaTrack* track) {
+	double volume = 0.0;
+	if ( !GetTrackUIVolPan(track, &volume, NULL) )
+		return;
 	ostringstream s;
 	s << fixed << setprecision(2);
-	s << VAL2DB(*(double*)GetSetMediaTrackInfo(track, "D_VOL", NULL));
+	s << VAL2DB(volume);
 	outputMessage(s);
 }
 
@@ -602,7 +605,10 @@ void postChangeTrackPan(int command) {
 	MediaTrack* track = GetLastTouchedTrack();
 	if (!track)
 		return;
-	double pan = *(double*)GetSetMediaTrackInfo(track, "D_PAN", NULL) * 100;
+	double pan =0.0;
+	if ( !GetTrackUIVolPan(track, NULL, &pan) )
+		return;
+	pan *=100.0;
 	ostringstream s;
 	if (pan == 0)
 		s << "center";


### PR DESCRIPTION
The actions for nudge volume and pan, bound to alt+arrow keys, reported
the wrong value if the automation mode was anything but trim/read. this
commit reports the correct value.

Fixes #112.