### PR TITLE
Automation actions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -483,6 +483,9 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Move to previous envelope point (leaving other points selected): alt+shift+j
 - OSARA: Move to next transient: tab
 - OSARA: Move to previous transient: shift+tab
+- OSARA: Cycle automation mode of selected tracks
+- OSARA: Report global / Track Automation Mode
+- OSARA: Toggle global automation override between latch preview and off
 
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f

--- a/src/osara.h
+++ b/src/osara.h
@@ -136,6 +136,8 @@
 #define REAPERAPI_WANT_plugin_register
 #define REAPERAPI_WANT_GetTrackUIVolPan
 #define REAPERAPI_WANT_GetGlobalAutomationOverride
+#define REAPERAPI_WANT_SetGlobalAutomationOverride
+#define REAPERAPI_WANT_GetTrackAutomationMode
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -138,6 +138,9 @@
 #define REAPERAPI_WANT_GetGlobalAutomationOverride
 #define REAPERAPI_WANT_SetGlobalAutomationOverride
 #define REAPERAPI_WANT_GetTrackAutomationMode
+#define REAPERAPI_WANT_CountSelectedTracks2
+#define REAPERAPI_WANT_GetSelectedTrack2
+#define REAPERAPI_WANT_SetTrackAutomationMode
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2056,7 +2056,7 @@ void cmdShowContextMenu3(Command* command) {
 }
 
 void cmdReportAutomationMode(Command* command) {
-	// This reports the global automation override if set, otherwise tcurrent track automation mode.
+	// This reports the global automation override if set, otherwise the current track automation mode.
 	ostringstream s;
 	MediaTrack* track = GetLastTouchedTrack();
 	if (GetGlobalAutomationOverride() >= 0) {
@@ -2071,18 +2071,19 @@ void cmdToggleGlobalAutomationLatchPreview(Command* command) {
 	if (GetGlobalAutomationOverride() == 5) {  // in latch preview mode
 		SetGlobalAutomationOverride(-1);
 		outputMessage("Global automation override off");
-	}
-	else { //not in latch preview.
-	 		SetGlobalAutomationOverride(5);
+	} else { //not in latch preview.
+		SetGlobalAutomationOverride(5);
 		outputMessage("Global automation override latch preview");
 	}
 }
 
 void cmdCycleTrackAutomation(Command* command) {
 	int count = CountSelectedTracks2(0, true);
-	if (count == 0)
+	if (count == 0) {
+		outputMessage("No selected tracks");
 		return;
-	int oldmode = GetTrackAutomationMode(GetSelectedTrack2(0, 0, true));
+	}
+	int oldmode = GetTrackAutomationMode(GetLastTouchedTrack());
 	int newmode = oldmode + 1;
 	if (newmode > 5)
 		newmode = 0;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2055,6 +2055,29 @@ void cmdShowContextMenu3(Command* command) {
 	showReaperContextMenu(2);
 }
 
+void cmdReportAutomationMode(Command* command) {
+	// This reports the global automation override if set, otherwise tcurrent track automation mode.
+	ostringstream s;
+	MediaTrack* track = GetLastTouchedTrack();
+	if (GetGlobalAutomationOverride() >= 0) {
+		s << "global automation override " << automationModeAsString(GetGlobalAutomationOverride());
+	} else {
+		s << "track automation mode " << automationModeAsString(GetTrackAutomationMode(track));
+	}
+	outputMessage(s);
+}
+
+void cmdToggleGlobalAutomationLatchPreview(Command* command) {
+	if (GetGlobalAutomationOverride() == 5) {  // in latch preview mode
+		SetGlobalAutomationOverride(-1);
+		outputMessage("Global automation override off");
+	}
+	else { //not in latch preview.
+	 		SetGlobalAutomationOverride(5);
+		outputMessage("Global automation override latch preview");
+	}
+}
+
 // See the Configuration section of the code below.
 void cmdConfig(Command* command);
 
@@ -2162,7 +2185,8 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show first context menu (depending on focus)"}, "OSARA_CONTEXTMENU1", cmdShowContextMenu1},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show second context menu (depending on focus)"}, "OSARA_CONTEXTMENU2", cmdShowContextMenu2},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show third context menu (depending on focus)"}, "OSARA_CONTEXTMENU3", cmdShowContextMenu3},
-	{MAIN_SECTION, {DEFACCEL, "OSARA: Configuration"}, "OSARA_CONFIG", cmdConfig},
+	{MAIN_SECTION, {DEFACCEL, "OSARA: Configuration"}, "OSARA_CONFIG", cmdConfig},{MAIN_SECTION, {DEFACCEL, "OSARA: Report global / Track Automation Mode"}, "OSARA_REPORTAUTOMATIONMODE", cmdReportAutomationMode},
+	{ MAIN_SECTION, {DEFACCEL, "OSARA: Toggle global automation override between latch preview and off"}, "OSARA_TOGGLEGLOBALAUTOMATIONLATCHPREVIEW", cmdToggleGlobalAutomationLatchPreview },
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Enable noncontiguous selection/toggle selection of current chord/note"}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next chord"}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous chord"}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2078,6 +2078,24 @@ void cmdToggleGlobalAutomationLatchPreview(Command* command) {
 	}
 }
 
+void cmdCycleTrackAutomation(Command* command) {
+	int count = CountSelectedTracks2(0, true);
+	if (count == 0)
+		return;
+	int oldmode = GetTrackAutomationMode(GetSelectedTrack2(0, 0, true));
+	int newmode = oldmode + 1;
+	if (newmode > 5)
+		newmode = 0;
+	for (int tracknum = 0; tracknum < count; ++tracknum) {
+		SetTrackAutomationMode(GetSelectedTrack2(0, tracknum, true), newmode);
+	}
+	ostringstream s;
+	s << "automation mode ";
+	s << automationModeAsString(newmode);
+	s << " for selected tracks";
+	outputMessage(s);
+}
+
 // See the Configuration section of the code below.
 void cmdConfig(Command* command);
 
@@ -2185,8 +2203,10 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show first context menu (depending on focus)"}, "OSARA_CONTEXTMENU1", cmdShowContextMenu1},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show second context menu (depending on focus)"}, "OSARA_CONTEXTMENU2", cmdShowContextMenu2},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Show third context menu (depending on focus)"}, "OSARA_CONTEXTMENU3", cmdShowContextMenu3},
-	{MAIN_SECTION, {DEFACCEL, "OSARA: Configuration"}, "OSARA_CONFIG", cmdConfig},{MAIN_SECTION, {DEFACCEL, "OSARA: Report global / Track Automation Mode"}, "OSARA_REPORTAUTOMATIONMODE", cmdReportAutomationMode},
+	{MAIN_SECTION, {DEFACCEL, "OSARA: Configuration"}, "OSARA_CONFIG", cmdConfig},
+	{MAIN_SECTION, {DEFACCEL, "OSARA: Report global / Track Automation Mode"}, "OSARA_REPORTAUTOMATIONMODE", cmdReportAutomationMode},
 	{ MAIN_SECTION, {DEFACCEL, "OSARA: Toggle global automation override between latch preview and off"}, "OSARA_TOGGLEGLOBALAUTOMATIONLATCHPREVIEW", cmdToggleGlobalAutomationLatchPreview },
+	{ MAIN_SECTION, {DEFACCEL, "OSARA: Cycle automation mode of selected tracks"}, "OSARA_CYCLETRACKAUTOMATION", cmdCycleTrackAutomation},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Enable noncontiguous selection/toggle selection of current chord/note"}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next chord"}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous chord"}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},


### PR DESCRIPTION
Hi.  This adds automation actions as discussed on the Wahtsapp group.

OSARA: Toggle global automation override between latch preview and off
OSARA: Report global / Track Automation Mode: Reports the global automation override if set, otherwise reports the automation mode of the current track
OSARA: Cycle automation mode of selected tracks: Cycles through automation modes for selected tracks.  This is needed because the sws action for cycling automation mode doesn't ensure that all selected tracks are set to the same mode.  

This depends on code in pr #216 
