### PR TITLE
Add action to cycle through midi recording modes on selected tracks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -486,6 +486,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Cycle automation mode of selected tracks
 - OSARA: Report global / Track Automation Mode
 - OSARA: Toggle global automation override between latch preview and off
+- OSARA: Cycle through midi recording modes of selected tracks
 
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f

--- a/src/osara.h
+++ b/src/osara.h
@@ -141,6 +141,7 @@
 #define REAPERAPI_WANT_CountSelectedTracks2
 #define REAPERAPI_WANT_GetSelectedTrack2
 #define REAPERAPI_WANT_SetTrackAutomationMode
+#define REAPERAPI_WANT_SetMediaTrackInfo_Value
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -356,29 +356,29 @@ const char* automationModeAsString(int mode) {
 }
 
 const char* recordingModeAsString(int mode) {
-	switch (mode) {
+	switch (mode) { //fixme: this list is incomplete, but the other modes are currently not used by Osara.
 		case 0:
-			return "Input";
+			return "input";
 		case 1:
-			return "Output (stereo)";
+			return "output (stereo)";
 		case 2:
-			return "Disabled";
+			return "disabled";
 		case 3:
-			return "Output (stereo, latency compensated)";
+			return "output (stereo, latency compensated)";
 		case 4:
-			return "Output (midi)";
+			return "output (midi)";
 		case 5:
-			return "Output (mono)";
+			return "output (mono)";
 		case 6:
-			return "Output (mono, latency compensated)";
+			return "output (mono, latency compensated)";
 		case 7:
-			return "Midi overdub";
+			return "midi overdub";
 		case 8:
-			return "Midi replace";
+			return "midi replace";
 		case 9:
-			return "Midi touch-replace";
+			return "midi touch-replace";
 		case 16:
-			return "Midi latch-replace";
+			return "midi latch-replace";
 		default:
 			return "unknown";
 	}


### PR DESCRIPTION
Add the action "OSARA: Cycle through midi recording modes of selected
tracks" which cycles through the midi recording modes, insuring that all
selected tracks have the same mode.

fixes #188.