### PR TITLE
Add feedback for note selection commands in the MIDI editor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Decrease pitch cursor one semitone: Alt+DownArrow or NumPad2
 - Edit: Delete events: Delete
 - Edit: Insert note at edit cursor: I
+- Edit: Select all events: Ctrl+A
+- Edit: Select all notes in time selection: Ctrl+Alt+E
+- Invert selection: Ctrl+I
+- Select all notes with the same pitch: Ctrl+Shift+A
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/readme.md
+++ b/readme.md
@@ -490,6 +490,14 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Cycle automation mode of selected tracks
 - OSARA: Report global / Track Automation Mode
 - OSARA: Toggle global automation override between latch preview and off
+- Global automation override: All automation in latch mode
+- Global automation override: All automation in latch preview mode
+- Global automation override: All automation in read mode
+- Global automation override: All automation in touch mode
+- Global automation override: All automation in trim/read mode
+- Global automation override: All automation in write mode
+- Global automation override: Bypass all automation
+- Global automation override: No override (set automation modes per track)
 - OSARA: Cycle through midi recording modes of selected tracks
 
 #### MIDI Event List Editor

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Move edit cursor to next tempo or time signature change: Control+'
 - Markers: Delete time signature marker near cursor
 
-#### Envelopes
+#### Automation
 - Item edit: Move items/envelope points up one track/a bit: NumPad8
 - Item edit: Move items/envelope points down one track/a bit: NumPad2
 - (SWS extension) SWS/FNG: Move selected envelope points up: Alt+NumPad8
@@ -185,6 +185,14 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Envelope: Delete all selected points: Control+Shift+Delete
 - Envelope: Delete all points in time selection: Alt+Shift+Delete
 - Envelope: Insert new point at current position: Shift+E
+- Global automation override: All automation in latch mode
+- Global automation override: All automation in latch preview mode
+- Global automation override: All automation in read mode
+- Global automation override: All automation in touch mode
+- Global automation override: All automation in trim/read mode
+- Global automation override: All automation in write mode
+- Global automation override: Bypass all automation
+- Global automation override: No override (set automation modes per track)
 
 #### Zoom
 - Zoom out horizontal: - or NumPad-
@@ -490,14 +498,6 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Cycle automation mode of selected tracks
 - OSARA: Report global / Track Automation Mode
 - OSARA: Toggle global automation override between latch preview and off
-- Global automation override: All automation in latch mode
-- Global automation override: All automation in latch preview mode
-- Global automation override: All automation in read mode
-- Global automation override: All automation in touch mode
-- Global automation override: All automation in trim/read mode
-- Global automation override: All automation in write mode
-- Global automation override: Bypass all automation
-- Global automation override: No override (set automation modes per track)
 - OSARA: Cycle through midi recording modes of selected tracks
 
 #### MIDI Event List Editor

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -484,6 +484,24 @@ void cmdMidiDeleteEvents(Command* command) {
 	outputMessage(s);
 }
 
+void cmdMidiSelectNotes(Command* command) {
+	int noteCount;
+	HWND editor = MIDIEditor_GetActive();
+	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	int evtx=0;
+	int count=0;
+	for(;;){
+		evtx = MIDI_EnumSelEvts(take, evtx);
+		if (evtx == -1)
+			break;
+		++count;
+	}
+	ostringstream s;
+	s << count << " event" << ((count == 1) ? "" : "s") << " selected";
+	outputMessage(s);
+}
+
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command) {
 	HWND focus = GetFocus();

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -21,6 +21,7 @@ void cmdMidiMoveToPreviousNoteInChordKeepSel(Command* command);
 void cmdMidiMovePitchCursor(Command* command);
 void cmdMidiInsertNote(Command* command);
 void cmdMidiDeleteEvents(Command* command);
+void cmdMidiSelectNotes(Command* command);
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);

--- a/src/osara.h
+++ b/src/osara.h
@@ -142,6 +142,7 @@
 #define REAPERAPI_WANT_GetSelectedTrack2
 #define REAPERAPI_WANT_SetTrackAutomationMode
 #define REAPERAPI_WANT_SetMediaTrackInfo_Value
+#define REAPERAPI_WANT_MIDI_EnumSelEvts
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2220,6 +2220,10 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0, 40050}, NULL}, NULL, cmdMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
 	{MIDI_EDITOR_SECTION, {{0, 0, 40667}, NULL}, NULL, cmdMidiDeleteEvents}, // Edit: Delete events
 	{MIDI_EDITOR_SECTION, {{0, 0, 40051}, NULL}, NULL, cmdMidiInsertNote}, // Edit: Insert note at edit cursor
+	{MIDI_EDITOR_SECTION, {{0, 0,40746}, NULL}, NULL, cmdMidiSelectNotes}, // Edit: Select all notes in time selection
+	{MIDI_EDITOR_SECTION, {{0, 0,40006}, NULL}, NULL, cmdMidiSelectNotes}, // Edit: Select all events
+	{MIDI_EDITOR_SECTION, {{0, 0,40501}, NULL}, NULL, cmdMidiSelectNotes},// Invert selection
+	{MIDI_EDITOR_SECTION, {{0, 0,40434}, NULL}, NULL, cmdMidiSelectNotes},// Select all notes with the same pitch
 #ifdef _WIN32
 	{MIDI_EDITOR_SECTION, {{0, 0, 40762}, NULL}, NULL, cmdMidiFilterWindow}, // Filter: Show/hide filter window...
 	{MIDI_EDITOR_SECTION, {{ 0, 0, 40471}, NULL}, NULL, cmdMidiFilterWindow }, // Filter: Enable/disable event filter and show/hide filter window...


### PR DESCRIPTION
Add feedback for the following commands:
- Edit: Select all events
- Edit: Select all notes in time selection
- Invert selection
- Select all notes with the same pitch