### PR TITLE
Add feedback in the MIDI editor when moving to next/previous track/item

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Set length for next inserted note: 1/8: control+8
 - Set length for next inserted note: 1/8T: control+9
 - Set length for next inserted note: 1/32T: control+0
+- Activate next MIDI track: Ctrl+DownArrow
+- Activate previous MIDI track: Ctrl+UpArrow
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.
@@ -519,6 +521,10 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Report global / Track Automation Mode
 - OSARA: Toggle global automation override between latch preview and off
 - OSARA: Cycle through midi recording modes of selected tracks
+
+#### Midi editor
+- OSARA: Move to next midi item on track
+- OSARA: Move to previous midi item on track
 
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -506,7 +506,9 @@ void midiMoveToItem(int direction) {
 	HWND editor = MIDIEditor_GetActive();
 	MIDIEditor_OnCommand(editor, ((direction==1)?40798:40797)); // Contents: Activate next/previous MIDI media item on this track, clearing the editor first
 	MIDIEditor_OnCommand(editor, 40036); // View: Go to start of file
-	MIDIEditor_OnCommand(editor, NamedCommandLookup("_FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR")); // SWS/FNG: Select notes nearest edit cursor
+	int cmd = NamedCommandLookup("_FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR");
+	if(cmd>0)
+		MIDIEditor_OnCommand(editor, cmd); // SWS/FNG: Select notes nearest edit cursor
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	MediaItem* item = GetMediaItemTake_Item(take);
 	MediaTrack* track = GetMediaItem_Track(item);

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -502,6 +502,65 @@ void cmdMidiSelectNotes(Command* command) {
 	outputMessage(s);
 }
 
+void midiMoveToItem(int direction) {
+	HWND editor = MIDIEditor_GetActive();
+	MIDIEditor_OnCommand(editor, ((direction==1)?40798:40797)); // Contents: Activate next/previous MIDI media item on this track, clearing the editor first
+	MIDIEditor_OnCommand(editor, 40036); // View: Go to start of file
+	MIDIEditor_OnCommand(editor, NamedCommandLookup("_FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR")); // SWS/FNG: Select notes nearest edit cursor
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	MediaItem* item = GetMediaItemTake_Item(take);
+	MediaTrack* track = GetMediaItem_Track(item);
+	int count = CountTrackMediaItems(track);
+	int itemNum;
+	for (int i=0; i<count; ++i) {
+		MediaItem* itemTmp = GetTrackMediaItem(track, i);
+		if (itemTmp == item) {
+			itemNum = i+1;
+			break;
+		}
+	}
+	ostringstream s;
+	s << itemNum << " " << GetTakeName(take);
+	s << " " << formatCursorPosition();
+	outputMessage(s);
+}
+
+void cmdMidiMoveToNextItem(Command* command) {
+	Undo_BeginBlock();
+	midiMoveToItem(1);
+	Undo_EndBlock("OSARA: Move to next midi item on track", 0);
+}
+
+void cmdMidiMoveToPrevItem(Command* command) {
+	Undo_BeginBlock();
+	midiMoveToItem(-1);
+	Undo_EndBlock("OSARA: Move to previous midi item on track", 0);
+}
+
+void cmdMidiMoveToTrack(Command* command) {
+	HWND editor = MIDIEditor_GetActive();
+	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
+		MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	MediaItem* item = GetMediaItemTake_Item(take);
+	MediaTrack* track = GetMediaItem_Track(item);
+	int count = CountTrackMediaItems(track);
+	int itemNum;
+	for (int i=0; i<count; ++i) {
+		MediaItem* itemTmp = GetTrackMediaItem(track, i);
+		if (itemTmp == item) {
+			itemNum = i+1;
+			break;
+		}
+	}
+	ostringstream s;
+	int trackNum = (int)(size_t)GetSetMediaTrackInfo(track, "IP_TRACKNUMBER", NULL);
+	s << trackNum;
+	char* trackName = (char*)GetSetMediaTrackInfo(track, "P_NAME", NULL);
+	if (trackName)
+		s << " " << trackName;
+	s << " item " << itemNum << " " << GetTakeName(take);
+outputMessage(s);
+}
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command) {
 	HWND focus = GetFocus();

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -561,8 +561,9 @@ void cmdMidiMoveToTrack(Command* command) {
 	if (trackName)
 		s << " " << trackName;
 	s << " item " << itemNum << " " << GetTakeName(take);
-outputMessage(s);
+	outputMessage(s);
 }
+
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command) {
 	HWND focus = GetFocus();

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -22,6 +22,9 @@ void cmdMidiMovePitchCursor(Command* command);
 void cmdMidiInsertNote(Command* command);
 void cmdMidiDeleteEvents(Command* command);
 void cmdMidiSelectNotes(Command* command);
+void cmdMidiMoveToNextItem(Command* command) ;
+void cmdMidiMoveToPrevItem(Command* command) ;
+void cmdMidiMoveToTrack(Command* command);
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);

--- a/src/osara.h
+++ b/src/osara.h
@@ -143,6 +143,8 @@
 #define REAPERAPI_WANT_SetTrackAutomationMode
 #define REAPERAPI_WANT_SetMediaTrackInfo_Value
 #define REAPERAPI_WANT_MIDI_EnumSelEvts
+#define REAPERAPI_WANT_GetMediaItemTake_Item
+#define REAPERAPI_WANT_GetMediaItem_Track
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2247,6 +2247,8 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0,40006}, NULL}, NULL, cmdMidiSelectNotes}, // Edit: Select all events
 	{MIDI_EDITOR_SECTION, {{0, 0,40501}, NULL}, NULL, cmdMidiSelectNotes},// Invert selection
 	{MIDI_EDITOR_SECTION, {{0, 0,40434}, NULL}, NULL, cmdMidiSelectNotes},// Select all notes with the same pitch
+	{MIDI_EDITOR_SECTION, {{0, 0,40835}, NULL}, NULL, cmdMidiMoveToTrack}, // Activate next MIDI track
+	{MIDI_EDITOR_SECTION, {{0, 0,40836}, NULL}, NULL, cmdMidiMoveToTrack}, // Activate previous MIDI track
 #ifdef _WIN32
 	{MIDI_EDITOR_SECTION, {{0, 0, 40762}, NULL}, NULL, cmdMidiFilterWindow}, // Filter: Show/hide filter window...
 	{MIDI_EDITOR_SECTION, {{ 0, 0, 40471}, NULL}, NULL, cmdMidiFilterWindow }, // Filter: Enable/disable event filter and show/hide filter window...
@@ -2311,6 +2313,8 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous note in chord"}, "OSARA_PREVNOTE", cmdMidiMoveToPreviousNoteInChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next note in chord and add to selection"}, "OSARA_NEXTNOTEKEEPSEL", cmdMidiMoveToNextNoteInChordKeepSel},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous note in chord and add to selection"}, "OSARA_PREVNOTEKEEPSEL", cmdMidiMoveToPreviousNoteInChordKeepSel},
+	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous midi item on track"}, "OSARA_MIDIPREVITEM", cmdMidiMoveToPrevItem},
+	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next midi item on track"}, "OSARA_MIDINEXTITEM", cmdMidiMoveToNextItem},
 #ifdef _WIN32
 	{MIDI_EVENT_LIST_SECTION, {DEFACCEL, "OSARA: Focus event nearest edit cursor"}, "OSARA_FOCUSMIDIEVENT", cmdFocusNearestMidiEvent},
 #endif


### PR DESCRIPTION
Add feedback for:
* Activate next MIDI track
* Activate previous MIDI track

Add the following new actions to replace the custom actions previously assigned to Ctrl+Left and Ctrl+Right:
* OSARA: Move to previous midi item on track
* OSARA: Move to next midi item on track

Fixes #160