### PR TITLE
Add feedback for previous and next folder commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Track: Insert new track
 - Track: Cycle track folder state: Shift+Enter
 - Track: Cycle track folder collapsed state: Enter
+- SWS: Select nearest next folder
+- SWS: Select nearest previous folder
 - Track: Remove tracks
 
 #### Adjusting Track Parameters

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1049,6 +1049,8 @@ PostCustomCommand POST_CUSTOM_COMMANDS[] = {
 	{"_FNG_ENVUP", postMoveEnvelopePoint}, // SWS/FNG: Move selected envelope points up
 	{"_XENAKIOS_SELITEMSUNDEDCURSELTX", postSelectMultipleItems}, // Xenakios/SWS: Select items under edit cursor on selected tracks
 	{"_BR_CYCLE_RECORD_MODES", postCycleRecordMode}, // SWS/BR: Options - Cycle through record modes
+	{"_SWS_SELNEARESTNEXTFOLDER", postGoToTrack}, //SWS: Select nearest next folder
+	{"_SWS_SELNEARESTPREVFOLDER", postGoToTrack}, // SWS: Select nearest previous folder
 	{NULL},
 };
 map<int, PostCommandExecute> postCommandsMap;


### PR DESCRIPTION
Implement feedback for:
SWS: Select nearest previous folder
SWS: Select nearest next folder

Fixes #187.