### PR TITLE
Add feedback when toggling item mute and solo

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -147,6 +147,7 @@
 #define REAPERAPI_WANT_GetMediaItem_Track
 #define REAPERAPI_WANT_IsMediaItemSelected
 #define REAPERAPI_WANT_GetMediaItemInfo_Value
+#define REAPERAPI_WANT_GetMediaItem
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -894,8 +894,12 @@ void postToggleItemMute(int command) {
 		outputMessage(isItemMuted(GetSelectedMediaItem(0,0))?"muted":"unmuted");
 		return;
 	}
-	for (int i=0; i<count; i++)
-		isItemMuted(GetSelectedMediaItem(0, i))?muteCount++:unmuteCount++;
+	for (int i=0; i<count; ++i) {
+		if(isItemMuted(GetSelectedMediaItem(0, i)))
+			++muteCount;
+		else
+			++unmuteCount;
+	}
 	ostringstream s;
 	if(muteCount>0){
 		s<<muteCount<<" item"<<((muteCount==1)?"":"s") <<" muted";
@@ -912,10 +916,12 @@ void postToggleItemSolo(int command) {
 	int selectedCount = CountSelectedMediaItems(0);
 	if(selectedCount==0)
 		return;
-	for(int i=0; i<itemCount; i++) {
+	for(int i=0; i<itemCount; ++i) {
 		MediaItem* item = GetMediaItem(0, i);
-		if((!isItemSelected(item)) && (!isItemMuted(item)))
+		if((!isItemSelected(item)) && (!isItemMuted(item)))  {
 			soloed=false;
+			break;
+		}
 	}
 	if(selectedCount==1) {
 		outputMessage(soloed?"soloed":"unsoloed");
@@ -1086,7 +1092,7 @@ PostCommand POST_COMMANDS[] = {
 	{40118, postMoveEnvelopePoint}, // Item edit: Move items/envelope points down one track/a bit
 	{40696, postRenameTrack}, // Track: Rename last touched track
 	{40175, postToggleItemMute}, // Item properties: Toggle mute
-		{41561, postToggleItemSolo}, // Item properties: Toggle solo
+	{41561, postToggleItemSolo}, // Item properties: Toggle solo
 	{40626, postSetSelectionEnd}, // Time selection: Set end point
 	{40917, postToggleMasterMono}, // Master track: Toggle stereo/mono (L+R)
 	{40041, postToggleAutoCrossfade}, // Options: Toggle auto-crossfade on/off

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -880,12 +880,52 @@ void postRenameTrack(int command) {
 	outputMessage("Track name");
 }
 
+bool isItemMuted(MediaItem* item) {
+	return *(bool*)GetSetMediaItemInfo(item, "B_MUTE", NULL);
+}
+
 void postToggleItemMute(int command) {
-	MediaItem* item = GetSelectedMediaItem(0, 0);
-	if (!item)
+	int muteCount=0;
+	int unmuteCount=0;
+	int count = CountSelectedMediaItems(0);
+	if(count==0)
 		return;
-	outputMessage(*(bool*)GetSetMediaItemInfo(item, "B_MUTE", NULL) ?
-		"muted" : "unmuted");
+	if(count==1)  {
+		outputMessage(isItemMuted(GetSelectedMediaItem(0,0))?"muted":"unmuted");
+		return;
+	}
+	for (int i=0; i<count; i++)
+		isItemMuted(GetSelectedMediaItem(0, i))?muteCount++:unmuteCount++;
+	ostringstream s;
+	if(muteCount>0){
+		s<<muteCount<<" item"<<((muteCount==1)?"":"s") <<" muted";
+		s<<((unmuteCount>0)?", ":"");
+	}
+	if(unmuteCount>0) 
+		s<<unmuteCount<<" item"<<((unmuteCount==1)?"":"s") <<" unmuted";
+	outputMessage(s);
+}
+
+void postToggleItemSolo(int command) {
+	int soloCount=0;
+	int unsoloCount=0;
+	int count = CountSelectedMediaItems(0);
+	if(count==0)
+		return;
+	if(count==1)  {
+		outputMessage(isItemMuted(GetSelectedMediaItem(0,0))?"unsoloed":"soloed");
+		return;
+	}
+	for (int i=0; i<count; i++)
+		isItemMuted(GetSelectedMediaItem(0, i))?unsoloCount++:soloCount++;
+	ostringstream s;
+	if(soloCount>0){
+		s<<soloCount<<" item"<<((soloCount==1)?"":"s") <<" soloed";
+		s<<((unsoloCount>0)?", ":"");
+	}
+	if(unsoloCount>0) 
+		s<<unsoloCount<<" item"<<((unsoloCount==1)?"":"s") <<" unsoloed";
+	outputMessage(s);
 }
 
 void postSetSelectionEnd(int command) {
@@ -1048,6 +1088,7 @@ PostCommand POST_COMMANDS[] = {
 	{40118, postMoveEnvelopePoint}, // Item edit: Move items/envelope points down one track/a bit
 	{40696, postRenameTrack}, // Track: Rename last touched track
 	{40175, postToggleItemMute}, // Item properties: Toggle mute
+		{41561, postToggleItemSolo}, // Item properties: Toggle solo
 	{40626, postSetSelectionEnd}, // Time selection: Set end point
 	{40917, postToggleMasterMono}, // Master track: Toggle stereo/mono (L+R)
 	{40041, postToggleAutoCrossfade}, // Options: Toggle auto-crossfade on/off

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -907,24 +907,22 @@ void postToggleItemMute(int command) {
 }
 
 void postToggleItemSolo(int command) {
-	int soloCount=0;
-	int unsoloCount=0;
-	int count = CountSelectedMediaItems(0);
-	if(count==0)
+	bool soloed=true;
+	int itemCount=CountMediaItems(0);
+	int selectedCount = CountSelectedMediaItems(0);
+	if(selectedCount==0)
 		return;
-	if(count==1)  {
-		outputMessage(isItemMuted(GetSelectedMediaItem(0,0))?"unsoloed":"soloed");
+	for(int i=0; i<itemCount; i++) {
+		MediaItem* item = GetMediaItem(0, i);
+		if((!isItemSelected(item)) && (!isItemMuted(item)))
+			soloed=false;
+	}
+	if(selectedCount==1) {
+		outputMessage(soloed?"soloed":"unsoloed");
 		return;
 	}
-	for (int i=0; i<count; i++)
-		isItemMuted(GetSelectedMediaItem(0, i))?unsoloCount++:soloCount++;
 	ostringstream s;
-	if(soloCount>0){
-		s<<soloCount<<" item"<<((soloCount==1)?"":"s") <<" soloed";
-		s<<((unsoloCount>0)?", ":"");
-	}
-	if(unsoloCount>0) 
-		s<<unsoloCount<<" item"<<((unsoloCount==1)?"":"s") <<" unsoloed";
+	s<<selectedCount<<" items "<<(soloed?"soloed":"unsoloed");
 	outputMessage(s);
 }
 


### PR DESCRIPTION
This reports the number of items muted and the number of items unmuted.  

It also adds feedback for item solo.  The problem with item solo is that it seams to be implemented by muting every other item in the project, not as a separate solo flag.  

Partial fix for #172 

Item solo state can't be reported as items don't appear to have a solo flag.