### PR TITLE
Update build environment to use python 3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,13 @@ branches:
   - master
 
 environment:
- PY_PYTHON: 2.7-32
+ PY_PYTHON: 3.7-32
  encFileKey:
   secure: hN4Qfteiu6qqPajSvT+vrPfVoazOY+MFAlwUt/kZSnM=
 
 init:
  - ps:       Update-AppveyorBuild -Version ("$env:APPVEYOR_BUILD_VERSION," + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8))
- # We must use easy_install instead of pip because of a scons packaging bug.
- # See https://github.com/SCons/scons/issues/2769
- - py -m easy_install scons
+ - py -m pip install scons
 
 clone_depth: 1
 

--- a/readme.md
+++ b/readme.md
@@ -562,9 +562,8 @@ To build OSARA, you will need:
 - Mac only: Either the [command line developer tools](https://developer.apple.com/library/ios/technotes/tn2339/_index.html) or Xcode 9:
 	* Xcode 10 is not yet supported.
 	* You can download Xcode 9 from the [Apple Developer Downloads page](https://developer.apple.com/downloads/more/).
-- Python, version 2.7:
+- Python, version 2.7 or later:
 	* This is needed by SCons.
-	* Python 3 and later are not yet supported.
 	* [Download Python](https://www.python.org/downloads/)
 - [SCons](https://www.scons.org/), version 3.0.4 or later:
 	* Once Python is installed, you should be able to install SCons by simply running this at the command line: `pip install scons`

--- a/sconstruct
+++ b/sconstruct
@@ -22,12 +22,15 @@ if env["PLATFORM"] == "win32":
 			exports={"env": archEnv},
 			variant_dir="build/%s" % arch, duplicate=False)
 
-	import _winreg
+	try:
+		import winreg
+	except ImportError:
+		import _winreg as winreg
 	# Get the path to makensis.
 	try:
-		with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NSIS",
-				0, _winreg.KEY_READ | _winreg.KEY_WOW64_32KEY) as nsisKey:
-			makensis = os.path.join(_winreg.QueryValueEx(nsisKey, None)[0], "makensis.exe")
+		with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NSIS",
+				0, winreg.KEY_READ | winreg.KEY_WOW64_32KEY) as nsisKey:
+			makensis = os.path.join(winreg.QueryValueEx(nsisKey, None)[0], "makensis.exe")
 	except WindowsError:
 		makensis = "makensis"
 	installer = env.Command("installer/osara_${version}.exe", ["installer/osara.nsi", "build"],


### PR DESCRIPTION
The SCons environment still relied on Python 2 to be run. This pr:

1. Adds support for running SCons with Python 3, while being backwards compatible for Python 2 users
2. On Appveyor, run SCons under Python 3.7. Not sure whether 3.8 is there yet
3. Install scons with pip, as this works OK nowadays.