### PR TITLE
Fix rounding error in formatTime()

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -137,13 +137,22 @@ string formatTime(double time, TimeFormat format, bool isLength, bool useCache, 
 	switch (format) {
 		case TF_MEASURE: {
 			int measure;
-			double beat = TimeMap2_timeToBeats(NULL, time, &measure, NULL, NULL, NULL);
+			int measureLength;
+			double beat = TimeMap2_timeToBeats(NULL, time, &measure, &measureLength, NULL, NULL);
 			int wholeBeat = (int)beat;
+			int beatPercent = lround((beat - wholeBeat) * 100)  ;
+			if(beatPercent==100) {
+				beatPercent = 0;
+				++wholeBeat;
+			}
+			if(wholeBeat==measureLength) {
+				wholeBeat = 0;
+				++measure;
+			}
 			if (!isLength) {
 				++measure;
 				++wholeBeat;
 			}
-			int beatPercent = (int)(beat * 100) % 100;
 			if (!useCache || measure != oldMeasure) {
 				if (isLength) {
 					if (includeZeros || measure != 0)


### PR DESCRIPTION
It has been reported by several users that notes in the midi editor are announced by osara as having a position 1% earlier than where they actually are, which can be checked in the note properties.  I haven't found a reliable way to reproduce this in the midi editor, although I have seen it myself.  It is easy to reproduce in the main window however:

1.  zoom in to a high number of pixels per second
2. position the edit cursor exactly on a beat
3. move 1 pixel lef.
4. osara says the edit cursor is at 99% of the previous beat
5. Check the value in the jump dialogue, it doesn't change.


This is a change to formatTime() that causes it to round to the nearest beat percentage.  It should make osara report the same position as can be seen in the jump dialogue.