### PR TITLE
Respect note length when previewing inserted notes

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -521,7 +521,7 @@ void cmdMidiInsertNote(Command* command) {
 	// Play the inserted note.
 	previewNotes(take, {note});
 	ostringstream s;
-		if (shouldReportNotes) {
+	if (shouldReportNotes) {
 		s << getMidiNoteName(take, note.pitch, note.channel) << " ";
 		s << formatTime(note.getLength(), TF_MEASURE, true, false, false);
 		s << ", ";

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -344,6 +344,26 @@ bool isNoteSelected(MediaItem_Take* take, const int note) {
 	return sel;
 }
 
+vector<MidiNote> getSelectedNotes(MediaItem_Take* take, int offset=-1, bool getPosition=true, bool getPitch=true, bool getVelocity=true) {
+	int noteIndex = offset;
+	vector<MidiNote> notes;
+	for(;;){
+		noteIndex = MIDI_EnumSelNotes(take, noteIndex);
+		if (noteIndex == -1) {
+			break;
+		}
+		double start, end;
+		int chan, pitch, vel;
+		MIDI_GetNote(take, noteIndex, NULL, NULL, getPosition ? &start: NULL, getPosition? &end: NULL, &chan, getPitch ? &pitch: NULL, getVelocity ? &vel: NULL);
+		if (getPosition) {
+			start = MIDI_GetProjTimeFromPPQPos(take, start);
+			end = MIDI_GetProjTimeFromPPQPos(take, end);
+		}
+		notes.push_back({chan, pitch, vel, noteIndex, start, end});
+	}
+	return notes;
+}
+
 void cmdMidiToggleSelection(Command* command) {
 	if (isSelectionContiguous) {
 		isSelectionContiguous = false;
@@ -492,12 +512,24 @@ void cmdMidiInsertNote(Command* command) {
 	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
 	if (MIDI_CountEvts(take, NULL, NULL, NULL) <= oldCount)
 		return; // Not inserted.
-	// Play the inserted note.
 	int pitch = MIDIEditor_GetSetting_int(editor, "active_note_row");
-	int chan = MIDIEditor_GetSetting_int(editor, "default_note_chan");
-	int vel = MIDIEditor_GetSetting_int(editor, "default_note_vel");
-	previewNotes(take, {{chan, pitch, vel}});
-	outputMessage(formatCursorPosition(TF_MEASURE));
+	// Get selected notes.
+	vector<MidiNote> selectedNotes = getSelectedNotes(take);
+	// Find the just inserted note based on its pitch, as that makes it unique.
+	auto note = *(find_if(
+		selectedNotes.begin(), selectedNotes.end(),
+		[pitch](MidiNote n) { return n.pitch == pitch; })
+	);
+	// Play the inserted note.
+	previewNotes(take, {note});
+	ostringstream s;
+		if (shouldReportNotes) {
+		s << getMidiNoteName(take, note.pitch, note.channel) << " ";
+		s << formatTime(note.getLength(), TF_MEASURE, true, false, false);
+		s << ", ";
+	}
+	s << formatCursorPosition(TF_MEASURE);
+	outputMessage(s);
 }
 
 void cmdMidiDeleteEvents(Command* command) {

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -344,7 +344,7 @@ bool isNoteSelected(MediaItem_Take* take, const int note) {
 	return sel;
 }
 
-vector<MidiNote> getSelectedNotes(MediaItem_Take* take, int offset=-1, bool getPosition=true, bool getPitch=true, bool getVelocity=true) {
+vector<MidiNote> getSelectedNotes(MediaItem_Take* take, int offset=-1) {
 	int noteIndex = offset;
 	vector<MidiNote> notes;
 	for(;;){
@@ -354,11 +354,9 @@ vector<MidiNote> getSelectedNotes(MediaItem_Take* take, int offset=-1, bool getP
 		}
 		double start, end;
 		int chan, pitch, vel;
-		MIDI_GetNote(take, noteIndex, NULL, NULL, getPosition ? &start: NULL, getPosition? &end: NULL, &chan, getPitch ? &pitch: NULL, getVelocity ? &vel: NULL);
-		if (getPosition) {
-			start = MIDI_GetProjTimeFromPPQPos(take, start);
-			end = MIDI_GetProjTimeFromPPQPos(take, end);
-		}
+		MIDI_GetNote(take, noteIndex, NULL, NULL, &start, &end, &chan, &pitch, &vel);
+		start = MIDI_GetProjTimeFromPPQPos(take, start);
+		end = MIDI_GetProjTimeFromPPQPos(take, end);
 		notes.push_back({chan, pitch, vel, noteIndex, start, end});
 	}
 	return notes;


### PR DESCRIPTION
Follow up of #251 
Starting point for #252 

When inserting a note, we now do the following after inserting:

1. Get the selected notes in the current take. This will be the new note, along with possible other notes. If you selected a chord before inserting a note, the chord will be selected including the new note.
2. As you couldn't insert multiple notes with the same pitch, pitch is something that makes a note unique. We also know the pitch at point of inserting. Therefore, we get the newly inserted note from the selected notes by comparing it with the current pitch.
3. Then, the inserted note is played. As a bonus, it will be announced when reporting notes is on.

This pr will be the fundament of other subsequent pull requests that report action feedback for several actions that act on selected notes (#252)