### PR TITLE
Add midi post actions for pitch, length and velocity changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,7 +321,6 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Note velocity +10: Alt+NumPad9
 - Edit: Note velocity -01: NumPad7
 - Edit: Note velocity -10: Alt+NumPad7
-- 
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/readme.md
+++ b/readme.md
@@ -275,8 +275,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Move edit cursor left by grid: Alt+Shift+Rightarrow
 - Navigate: Move edit cursor right one measure: PageDown
 - Navigate: Move edit cursor left one measure: PageUp
-- Edit: Increase pitch cursor one semitone: Alt+UpArrow or NumPad8
-- Edit: Decrease pitch cursor one semitone: Alt+DownArrow or NumPad2
+- Edit: Increase pitch cursor one semitone: Alt+UpArrow or Ctrl+NumPad8
+- Edit: Decrease pitch cursor one semitone: Alt+DownArrow or Ctrl+NumPad2
+- Edit: Increase pitch cursor one octave: Alt+Shift+UpArrow
+- Edit: Decrease pitch cursor one octave: Alt+Shift+DownArrow
 - Edit: Delete events: Delete
 - Edit: Insert note at edit cursor: I
 - Edit: Select all events: Ctrl+A
@@ -305,6 +307,21 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Set length for next inserted note: 1/32T: control+0
 - Activate next MIDI track: Ctrl+DownArrow
 - Activate previous MIDI track: Ctrl+UpArrow
+- Edit: Move notes up one semitone: NumPad8
+- Edit: Move notes down one semitone: NumPad2
+- Edit: Move notes up one semitone ignoring scale/key: Ctrl+Alt+NumPad8
+- Edit: Move notes down one semitone ignoring scale/key: Ctrl+Alt+NumPad2
+- Edit: Move notes up one octave: Alt+NumPad8
+- Edit: Move notes down one octave: Alt+NumPad2
+- Edit: Lengthen notes one pixel: Alt+NumPad3
+- Edit: Shorten notes one pixel: Alt+NumPad1
+- Edit: Lengthen notes one grid unit: NumPad3
+- Edit: Shorten notes one grid unit: NumPad1
+- Edit: Note velocity +01: NumPad9
+- Edit: Note velocity +10: Alt+NumPad9
+- Edit: Note velocity -01: NumPad7
+- Edit: Note velocity -10: Alt+NumPad7
+- 
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -515,8 +515,8 @@ void cmdMidiInsertNote(Command* command) {
 	// Find the just inserted note based on its pitch, as that makes it unique.
 	auto note = *(find_if(
 		selectedNotes.begin(), selectedNotes.end(),
-		[pitch](MidiNote n) { return n.pitch == pitch; })
-	);
+		[pitch](MidiNote n) { return n.pitch == pitch; }
+	));
 	// Play the inserted note.
 	previewNotes(take, {note});
 	ostringstream s;
@@ -667,12 +667,52 @@ void postMidiChangeVelocity(int command) {
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
+	if (!selectedNotes.size()) {
+		return;
+	}
+	bool generalize = false;
+	if (selectedNotes.size() >= 8) {
+		generalize = true;
+	} else {
+		// Get indexes vor the current chord.
+		auto chord = findChord(take, 0);
+		if (chord.first == -1) {
+			generalize = true;
+		} else {
+			generalize = !(all_of(
+				selectedNotes.begin(), selectedNotes.end(),
+				[chord](MidiNote n) { return chord.first <= n.index && n.index <= chord.second; }
+			));
+		}
+	}
 	// The Reaper action takes care of note preview.
 	ostringstream s;
-	for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
-		s << getMidiNoteName(take, note->pitch, note->channel) << "  " << note->velocity;
-		if (note != selectedNotes.cend() - 1) {
-			s << ", ";
+	if (generalize) {
+		auto count = selectedNotes.size();
+		s << count << (count == 1 ? " note" : " notes ");
+		switch (command) {
+			case 40462:
+				s << "velocity +1";
+				break;
+			case 40463:
+				s << "velocity -1";
+				break;
+			case 40464:
+				s << "velocity +10";
+				break;
+			case 40465:
+				s << "velocity -10";
+				break;
+			default:
+				s << "velocity changed";
+				break;
+		}
+	} else{
+		for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
+			s << getMidiNoteName(take, note->pitch, note->channel) << "  " << note->velocity;
+			if (note != selectedNotes.cend() - 1) {
+				s << ", ";
+			}
 		}
 	}
 	outputMessage(s);
@@ -683,14 +723,56 @@ void postMidiChangeLength(int command) {
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
-	previewNotes(take, selectedNotes);
+		if (!selectedNotes.size()) {
+		return;
+	}
+	bool generalize = false;
+	if (selectedNotes.size() >= 8) {
+		generalize = true;
+	} else {
+		// Get indexes vor the current chord.
+		auto chord = findChord(take, 0);
+		if (chord.first == -1) {
+			generalize = true;
+		} else {
+			generalize = !(all_of(
+				selectedNotes.begin(), selectedNotes.end(),
+				[chord](MidiNote n) { return chord.first <= n.index && n.index <= chord.second; }
+			));
+		}
+	}
+	if (!generalize) {
+		previewNotes(take, selectedNotes);
+	}
 	if (shouldReportNotes) {
 		ostringstream s;
-		for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
-			s << getMidiNoteName(take, note->pitch, note->channel) << " ";
-			s			<< formatTime(note->getLength(), TF_MEASURE, true, false, false);
-			if (note != selectedNotes.cend() - 1) {
-				s << ", ";
+		if (generalize) {
+			auto count = selectedNotes.size();
+			s << count << (count == 1 ? " note" : " notes ");
+			switch (command) {
+				case 40444:
+					s << "lengthened pixel";
+					break;
+				case 40445:
+					s << "shortened pixel";
+					break;
+				case 40446:
+					s << "lengthened grid unit";
+					break;
+				case 40447:
+					s << "shortened grid unit";
+					break;				
+				default:
+					s << "lengthchanged";
+					break;
+			}
+		} else{ 
+			for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
+				s << getMidiNoteName(take, note->pitch, note->channel) << " ";
+				s			<< formatTime(note->getLength(), TF_MEASURE, true, false, false);
+				if (note != selectedNotes.cend() - 1) {
+					s << ", ";
+				}
 			}
 		}
 		outputMessage(s);
@@ -705,12 +787,58 @@ void postMidiChangePitch(int command) {
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
+	if (!selectedNotes.size()) {
+		return;
+	}
+	bool generalize = false;
+	if (selectedNotes.size() >= 8) {
+		generalize = true;
+	} else {
+		// Get indexes vor the current chord.
+		auto chord = findChord(take, 0);
+		if (chord.first == -1) {
+			generalize = true;
+		} else {
+			generalize = !(all_of(
+				selectedNotes.begin(), selectedNotes.end(),
+				[chord](MidiNote n) { return chord.first <= n.index && n.index <= chord.second; }
+			));
+		}
+	}
 	// The Reaper action takes care of note preview.
 	ostringstream s;
-	for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
-		s << getMidiNoteName(take, note->pitch, note->channel);
-		if (note != selectedNotes.cend() - 1) {
-			s << ", ";
+	if (generalize) {
+		auto count = selectedNotes.size();
+		s << count << (count == 1 ? " note" : " notes ");
+		switch (command) {
+			case 40177:
+				s << "semitone up";
+				break;
+			case 40178:
+				s << "semitone down";
+				break;
+			case 40180:
+				s << "octave down";
+				break;
+			case 40181:
+				s << "octave up";
+				break;
+			case 41026:
+				s << "semitone up ignoring scale";
+				break;
+			case 41027:
+				s << "semitone down ignoring scale";
+				break;
+			default:
+				s << "pitch changed";
+				break;
+		}
+	} else{ 
+		for (auto note = selectedNotes.cbegin(); note != selectedNotes.cend(); ++note) {
+			s << getMidiNoteName(take, note->pitch, note->channel);
+			if (note != selectedNotes.cend() - 1) {
+				s << ", ";
+			}
 		}
 	}
 	outputMessage(s);

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -664,17 +664,17 @@ void postMidiChangeVelocity(int command) {
 		return;
 	}
 	HWND editor = MIDIEditor_GetActive();
-	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
-	if (!selectedNotes.size()) {
+	if (selectedNotes.size() == 0) {
 		return;
 	}
 	bool generalize = false;
 	if (selectedNotes.size() >= 8) {
 		generalize = true;
 	} else {
-		// Get indexes vor the current chord.
+		// Get indexes for the current chord.
 		auto chord = findChord(take, 0);
 		if (chord.first == -1) {
 			generalize = true;
@@ -723,14 +723,14 @@ void postMidiChangeLength(int command) {
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
-		if (!selectedNotes.size()) {
+		if (selectedNotes.size() == 0) {
 		return;
 	}
 	bool generalize = false;
 	if (selectedNotes.size() >= 8) {
 		generalize = true;
 	} else {
-		// Get indexes vor the current chord.
+		// Get indexes for the current chord.
 		auto chord = findChord(take, 0);
 		if (chord.first == -1) {
 			generalize = true;
@@ -763,7 +763,7 @@ void postMidiChangeLength(int command) {
 					s << "shortened grid unit";
 					break;				
 				default:
-					s << "lengthchanged";
+					s << "length changed";
 					break;
 			}
 		} else{ 
@@ -787,14 +787,14 @@ void postMidiChangePitch(int command) {
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
-	if (!selectedNotes.size()) {
+	if (selectedNotes.size() == 0) {
 		return;
 	}
 	bool generalize = false;
 	if (selectedNotes.size() >= 8) {
 		generalize = true;
 	} else {
-		// Get indexes vor the current chord.
+		// Get indexes for the current chord.
 		auto chord = findChord(take, 0);
 		if (chord.first == -1) {
 			generalize = true;

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -490,10 +490,9 @@ void cmdMidiMoveToPreviousNoteInChordKeepSel(Command* command) {
 	moveToNoteInChord(-1, false, isSelectionContiguous);
 }
 
-void cmdMidiMovePitchCursor(Command* command) {
+void postMidiMovePitchCursor(int command) {
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
-	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
 	int pitch = MIDIEditor_GetSetting_int(editor, "active_note_row");
 	int chan = MIDIEditor_GetSetting_int(editor, "default_note_chan");
 	int vel = MIDIEditor_GetSetting_int(editor, "default_note_vel");
@@ -541,10 +540,8 @@ void cmdMidiDeleteEvents(Command* command) {
 	outputMessage(s);
 }
 
-void cmdMidiSelectNotes(Command* command) {
-	int noteCount;
+void postMidiSelectNotes(int command) {
 	HWND editor = MIDIEditor_GetActive();
-	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	int noteIndex=-1;
 	int count=0;
@@ -661,3 +658,31 @@ void cmdMidiFilterWindow(Command *command) {
 }
 
 #endif // _WIN32
+
+string formatVelocity(int velocity) {
+	ostringstream s;
+	s << "velocity " << lround((velocity / 127) * 100) << "%";
+	return s.str();
+}
+
+void postMidiChangeVelocity(int command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
+	if (curNoteInChord == -1) {
+		return;
+	}
+	// Note in chord.
+	MidiNote note = findNoteInChord(take, 0);
+	if (note.channel == -1) {
+		return;
+	}
+	previewNotes(take, {note});
+	ostringstream s;
+	s << getMidiNoteName(take, note.pitch, note.channel) << " ";
+	s << formatVelocity(note.velocity);
+	outputMessage(s);
+}
+
+void postMidiChangeLength(int command) {
+
+}

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -32,3 +32,4 @@ void cmdMidiFilterWindow(Command* command);
 
 void postMidiChangeVelocity(int command);
 void postMidiChangeLength(int command);
+void postMidiChangePitch(int command);

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -18,10 +18,10 @@ void cmdMidiMoveToNextNoteInChord(Command* command);
 void cmdMidiMoveToPreviousNoteInChord(Command* command);
 void cmdMidiMoveToNextNoteInChordKeepSel(Command* command);
 void cmdMidiMoveToPreviousNoteInChordKeepSel(Command* command);
-void cmdMidiMovePitchCursor(Command* command);
+void postMidiMovePitchCursor(int command);
 void cmdMidiInsertNote(Command* command);
 void cmdMidiDeleteEvents(Command* command);
-void cmdMidiSelectNotes(Command* command);
+void postMidiSelectNotes(int command);
 void cmdMidiMoveToNextItem(Command* command) ;
 void cmdMidiMoveToPrevItem(Command* command) ;
 void cmdMidiMoveToTrack(Command* command);
@@ -29,3 +29,6 @@ void cmdMidiMoveToTrack(Command* command);
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);
 #endif
+
+void postMidiChangeVelocity(int command);
+void postMidiChangeLength(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1127,16 +1127,26 @@ PostCommand POST_COMMANDS[] = {
 	{0},
 };
 PostCommand MIDI_POST_COMMANDS[] = {
+	{40006, postMidiSelectNotes}, // Edit: Select all events
 	{40049, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
 	{40050, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
-	{40746, postMidiSelectNotes}, // Edit: Select all notes in time selection
-	{40006, postMidiSelectNotes}, // Edit: Select all events
-	{40501, postMidiSelectNotes}, // Invert selection
+	{40177, postMidiChangePitch}, // Edit: Move notes up one semitone
+	{40178, postMidiChangePitch}, // Edit: Move notes down one semitone
+	{40180, postMidiChangePitch}, // Edit: Move notes down one octave
+	{40181, postMidiChangePitch}, // Edit: Move notes up one octave
 	{40434, postMidiSelectNotes}, // Select all notes with the same pitch
+	{40444, postMidiChangeLength}, // Edit: Lengthen notes one pixel
+	{40445, postMidiChangeLength}, // Edit: Shorten notes one pixel
+	{40446, postMidiChangeLength}, // Edit: Lengthen notes one grid unit
+	{40447, postMidiChangeLength}, // Edit: Shorten notes one grid unit
 	{40462, postMidiChangeVelocity}, // Edit: Note velocity +01
 	{40463, postMidiChangeVelocity}, // Edit: Note velocity +10
 	{40464, postMidiChangeVelocity}, // Edit: Note velocity -01
 	{40465, postMidiChangeVelocity}, // Edit: Note velocity -10
+	{40501, postMidiSelectNotes}, // Invert selection
+	{40746, postMidiSelectNotes}, // Edit: Select all notes in time selection
+	{41026, postMidiChangePitch}, // Edit: Move notes up one semitone ignoring scale/key
+	{41027, postMidiChangePitch}, // Edit: Move notes down one semitone ignoring scale/key
 	{0},
 };
 PostCustomCommand POST_CUSTOM_COMMANDS[] = {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1126,6 +1126,19 @@ PostCommand POST_COMMANDS[] = {
 	{41819, postTogglePreRoll}, // Pre-roll: Toggle pre-roll on record
 	{0},
 };
+PostCommand MIDI_POST_COMMANDS[] = {
+	{40049, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
+	{40050, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
+	{40746, postMidiSelectNotes}, // Edit: Select all notes in time selection
+	{40006, postMidiSelectNotes}, // Edit: Select all events
+	{40501, postMidiSelectNotes}, // Invert selection
+	{40434, postMidiSelectNotes}, // Select all notes with the same pitch
+	{40462, postMidiChangeVelocity}, // Edit: Note velocity +01
+	{40463, postMidiChangeVelocity}, // Edit: Note velocity +10
+	{40464, postMidiChangeVelocity}, // Edit: Note velocity -01
+	{40465, postMidiChangeVelocity}, // Edit: Note velocity -10
+	{0},
+};
 PostCustomCommand POST_CUSTOM_COMMANDS[] = {
 	{"_XENAKIOS_NUDGSELTKVOLUP", postChangeTrackVolume}, // Xenakios/SWS: Nudge volume of selected tracks up
 	{"_XENAKIOS_NUDGSELTKVOLDOWN", postChangeTrackVolume}, // Xenakios/SWS: Nudge volume of selected tracks down
@@ -1154,6 +1167,7 @@ map<int, string> POST_COMMAND_MESSAGES = {
 	{40777, "grid eighth triplet"}, // Grid: Set to 1/12 (1/8 triplet)
 };
 
+map<int, PostCommandExecute> midiPostCommandsMap;
 map<int, string> MIDI_POST_COMMAND_MESSAGES = {
 	{40204, "grid whole"}, // Grid: Set to 1
 	{40203, "grid half"}, // Grid: Set to 1/2
@@ -2422,14 +2436,8 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0, 40048}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor right by grid
 	{MIDI_EDITOR_SECTION, {{0, 0, 40682}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor right one measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40683}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor left one measure
-	{MIDI_EDITOR_SECTION, {{0, 0, 40049}, NULL}, NULL, cmdMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
-	{MIDI_EDITOR_SECTION, {{0, 0, 40050}, NULL}, NULL, cmdMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
 	{MIDI_EDITOR_SECTION, {{0, 0, 40667}, NULL}, NULL, cmdMidiDeleteEvents}, // Edit: Delete events
 	{MIDI_EDITOR_SECTION, {{0, 0, 40051}, NULL}, NULL, cmdMidiInsertNote}, // Edit: Insert note at edit cursor
-	{MIDI_EDITOR_SECTION, {{0, 0,40746}, NULL}, NULL, cmdMidiSelectNotes}, // Edit: Select all notes in time selection
-	{MIDI_EDITOR_SECTION, {{0, 0,40006}, NULL}, NULL, cmdMidiSelectNotes}, // Edit: Select all events
-	{MIDI_EDITOR_SECTION, {{0, 0,40501}, NULL}, NULL, cmdMidiSelectNotes},// Invert selection
-	{MIDI_EDITOR_SECTION, {{0, 0,40434}, NULL}, NULL, cmdMidiSelectNotes},// Select all notes with the same pitch
 	{MIDI_EDITOR_SECTION, {{0, 0,40835}, NULL}, NULL, cmdMidiMoveToTrack}, // Activate next MIDI track
 	{MIDI_EDITOR_SECTION, {{0, 0,40836}, NULL}, NULL, cmdMidiMoveToTrack}, // Activate previous MIDI track
 #ifdef _WIN32
@@ -2583,6 +2591,15 @@ bool handlePostCommand(int section, int command) {
 			return true;
 		}
 	}else if (section==MIDI_EDITOR_SECTION) {
+		const auto it = midiPostCommandsMap.find(command);
+		if (it != midiPostCommandsMap.end()) {
+			isHandlingCommand = true;
+			HWND editor = MIDIEditor_GetActive();
+			MIDIEditor_OnCommand(editor, command);
+			it->second(command);
+			isHandlingCommand = false;
+			return true;
+		}
 		const auto mIt = MIDI_POST_COMMAND_MESSAGES.find(command);
 		if (mIt != MIDI_POST_COMMAND_MESSAGES.end()) {
 			isHandlingCommand = true;
@@ -2758,6 +2775,10 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 
 		for (int i = 0; POST_COMMANDS[i].cmd; ++i)
 			postCommandsMap.insert(make_pair(POST_COMMANDS[i].cmd, POST_COMMANDS[i].execute));
+
+		for (int i = 0; MIDI_POST_COMMANDS[i].cmd; ++i) {
+			midiPostCommandsMap.insert(make_pair(MIDI_POST_COMMANDS[i].cmd, MIDI_POST_COMMANDS[i].execute));
+		}
 
 		for (int i = 0; COMMANDS[i].execute; ++i) {
 			if (COMMANDS[i].id) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1134,6 +1134,8 @@ PostCommand MIDI_POST_COMMANDS[] = {
 	{40178, postMidiChangePitch}, // Edit: Move notes down one semitone
 	{40180, postMidiChangePitch}, // Edit: Move notes down one octave
 	{40181, postMidiChangePitch}, // Edit: Move notes up one octave
+	{40187, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one octave
+	{40188, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one octave
 	{40434, postMidiSelectNotes}, // Select all notes with the same pitch
 	{40444, postMidiChangeLength}, // Edit: Lengthen notes one pixel
 	{40445, postMidiChangeLength}, // Edit: Shorten notes one pixel


### PR DESCRIPTION
This does the following:

* Adds the ability to define post commands for midi actions
* Convert some midi command hooks into post commands
* Adds post commands for length, pitch and velocity changes