### PR TITLE
Create unicode Windows Installer

### DIFF
--- a/installer/osara.nsi
+++ b/installer/osara.nsi
@@ -10,6 +10,7 @@
 !include "nsDialogs.nsh"
 
 SetCompressor /SOLID LZMA
+Unicode true
 Name "OSARA"
 Caption "OSARA ${VERSION} Setup"
 OutFile "${OUTFILE}"


### PR DESCRIPTION
It turns out that NSIS is still producing an ansi installer for us, according to the following warning printed by NSIS 3.05:
`warning 7998: ANSI targets are deprecated`

> Starting with NSIS v3.0 you can choose to create Unicode installers by setting the Unicode attribute. These installers will not work on Windows 95/98/ME but they will allow you to display your installer in any Unicode language supported by the OS.
When building a Unicode installer NSIS variables can hold Unicode characters (0001-FFFF). There should be no need to modify your existing scripts. If you want to read/write Unicode files, specific instructions have been added to read/write UTF-16LE strings from/to disk.

[Reference](https://nsis.sourceforge.io/Docs/Chapter1.html#intro-unicode)

This pr adds the unicode flag, producing unicode installers from now on.

## Testing performed
1. Made sure that OSARA still installs after creating an installer with NSIS 3.05
2. Made sure that the warning is gone
3. Made sure that appveyor is using a version of NSIS that's compatible with this flag. They're using 3.04