### PR TITLE
Add support for Edit: In-/Decrease cc value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -322,7 +322,7 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Note velocity -01: NumPad7
 - Edit: Note velocity -10: Alt+NumPad7
 - Edit: Increase value a little bit for CC events
-- // Edit: Decrease value a little bit for CC events
+- Edit: Decrease value a little bit for CC events
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Note velocity +10: Alt+NumPad9
 - Edit: Note velocity -01: NumPad7
 - Edit: Note velocity -10: Alt+NumPad7
+- Edit: Increase value a little bit for CC events
+- // Edit: Decrease value a little bit for CC events
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -423,6 +423,23 @@ bool isCCSelected(MediaItem_Take* take, const int cc) {
 	return sel;
 }
 
+vector<MidiControlChange> getSelectedCCs(MediaItem_Take* take, int offset=-1) {
+	int ccIndex = offset;
+	vector<MidiControlChange> ccs;
+	for(;;){
+		ccIndex = MIDI_EnumSelCC(take, ccIndex);
+		if (ccIndex == -1) {
+			break;
+		}
+		double position;
+		int chan, control, value;
+		MIDI_GetCC(take, ccIndex, NULL, NULL, &position, NULL, &chan, &control, &value);
+		position = MIDI_GetProjTimeFromPPQPos(take, position);
+		ccs.push_back({chan, ccIndex, control, value, position});
+	}
+	return ccs;
+}
+
 void cmdMidiToggleSelection(Command* command) {
 	if (isSelectionContiguous) {
 		isSelectionContiguous = false;

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1080,3 +1080,36 @@ void postMidiChangePitch(int command) {
 	}
 	outputMessage(s);
 }
+
+void postMidiChangeCCValue(int command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
+	// Get selected CCs.
+	vector<MidiControlChange> selectedCCs = getSelectedCCs(take);
+	auto count = selectedCCs.size();
+	if (count == 0) {
+		return;
+	}
+	ostringstream s;
+	if (count > 1) {
+		s << count << " control values ";
+		switch (command) {
+			case 40676: {
+				s << "increased";
+				break;
+			}
+			case 40677: {
+				s << "decreased";
+				break;
+			}
+			default: {
+				s << "changed";
+				break;
+			}
+		}
+	} else{ 
+		auto cc = *selectedCCs.cbegin();
+		s << cc.value;
+	}
+	outputMessage(s);
+}

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -426,7 +426,7 @@ bool isCCSelected(MediaItem_Take* take, const int cc) {
 vector<MidiControlChange> getSelectedCCs(MediaItem_Take* take, int offset=-1) {
 	int ccIndex = offset;
 	vector<MidiControlChange> ccs;
-	for(;;){
+	for (;;) {
 		ccIndex = MIDI_EnumSelCC(take, ccIndex);
 		if (ccIndex == -1) {
 			break;
@@ -1083,7 +1083,7 @@ void postMidiChangePitch(int command) {
 
 void postMidiChangeCCValue(int command) {
 	HWND editor = MIDIEditor_GetActive();
-	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	// Get selected CCs.
 	vector<MidiControlChange> selectedCCs = getSelectedCCs(take);
 	auto count = selectedCCs.size();

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -37,3 +37,4 @@ void cmdMidiFilterWindow(Command* command);
 void postMidiChangeVelocity(int command);
 void postMidiChangeLength(int command);
 void postMidiChangePitch(int command);
+void postMidiChangeCCValue(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1146,6 +1146,8 @@ PostCommand MIDI_POST_COMMANDS[] = {
 	{40464, postMidiChangeVelocity}, // Edit: Note velocity -01
 	{40465, postMidiChangeVelocity}, // Edit: Note velocity -10
 	{40501, postMidiSelectNotes}, // Invert selection
+	{40676, postMidiChangeCCValue}, // Edit: Increase value a little bit for CC events
+	{40677, postMidiChangeCCValue}, // Edit: Decrease value a little bit for CC events
 	{40746, postMidiSelectNotes}, // Edit: Select all notes in time selection
 	{41026, postMidiChangePitch}, // Edit: Move notes up one semitone ignoring scale/key
 	{41027, postMidiChangePitch}, // Edit: Move notes down one semitone ignoring scale/key


### PR DESCRIPTION
This adds a post command that reports changes when using the Edit: Increase/Decrease value a little bit for CC events commands. When two or more events are selected, output is generalized.