### PR TITLE
Add post command for CC lane switching

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Note velocity -10: Alt+NumPad7
 - Edit: Increase value a little bit for CC events
 - Edit: Decrease value a little bit for CC events
+- CC: Next CC lane
+- CC: Previous CC lane
 
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1121,8 +1121,9 @@ void postMidiSwitchCCLane(int command) {
 	if (ccNum < 128) {
 		s << ccNum << " ";
 	}
-	char textBuffer[64];
-	MIDIEditor_GetSetting_str(editor, "last_clicked_cc_lane", textBuffer, 64);
+	const int BUFFER_LENGTH = 64;
+	char textBuffer[BUFFER_LENGTH];
+	MIDIEditor_GetSetting_str(editor, "last_clicked_cc_lane", textBuffer, BUFFER_LENGTH);
 	s << textBuffer;
 	outputMessage(s);
 }

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1113,3 +1113,16 @@ void postMidiChangeCCValue(int command) {
 	}
 	outputMessage(s);
 }
+
+void postMidiSwitchCCLane(int command) {
+	HWND editor = MIDIEditor_GetActive();
+	ostringstream s;
+	int ccNum = MIDIEditor_GetSetting_int(editor, "last_clicked_cc_lane");
+	if (ccNum < 128) {
+		s << ccNum << " ";
+	}
+	char textBuffer[64];
+	MIDIEditor_GetSetting_str(editor, "last_clicked_cc_lane", textBuffer, 64);
+	s << textBuffer;
+	outputMessage(s);
+}

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -38,3 +38,4 @@ void postMidiChangeVelocity(int command);
 void postMidiChangeLength(int command);
 void postMidiChangePitch(int command);
 void postMidiChangeCCValue(int command);
+void postMidiSwitchCCLane(int command);

--- a/src/osara.h
+++ b/src/osara.h
@@ -99,6 +99,7 @@
 #define REAPERAPI_WANT_MIDI_EnumSelNotes
 #define REAPERAPI_WANT_MIDI_EnumSelCC
 #define REAPERAPI_WANT_MIDIEditor_GetSetting_int
+#define REAPERAPI_WANT_MIDIEditor_GetSetting_str
 #define REAPERAPI_WANT_MIDIEditor_OnCommand
 #define REAPERAPI_WANT_TakeFX_GetNumParams
 #define REAPERAPI_WANT_TakeFX_GetParamName

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1136,7 +1136,9 @@ PostCommand MIDI_POST_COMMANDS[] = {
 	{40181, postMidiChangePitch}, // Edit: Move notes up one octave
 	{40187, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one octave
 	{40188, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one octave
-	{40434, postMidiSelectNotes}, // Select all notes with the same pitch
+	{40234, postMidiSwitchCCLane}, // CC: Next CC lane
+	{40235, postMidiSwitchCCLane}, // CC: Previous CC lane
+	{40435, postMidiSelectNotes}, // Select all notes with the same pitch
 	{40444, postMidiChangeLength}, // Edit: Lengthen notes one pixel
 	{40445, postMidiChangeLength}, // Edit: Shorten notes one pixel
 	{40446, postMidiChangeLength}, // Edit: Lengthen notes one grid unit


### PR DESCRIPTION
When using the CC: Next/Previous CC lane commands, feedback is now provided (i.e. the number/name of the lane is spoken).