### PR TITLE
Add action OSARA: Select all notes with the same pitch within time se…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -568,6 +568,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Move to previous CC
 - OSARA: Move to next CC and add to selection
 - OSARA: Move to previous CC and add to selection
+- OSARA: Select all notes with the same pitch starting in time selection
 
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -29,6 +29,7 @@ void cmdMidiMoveToPreviousCCKeepSel(Command* command);
 void cmdMidiMoveToNextItem(Command* command) ;
 void cmdMidiMoveToPrevItem(Command* command) ;
 void cmdMidiMoveToTrack(Command* command);
+void cmdMidiSelectSamePitchStartingInTimeSelection(Command* command) ;
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2614,6 +2614,7 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous CC and add to selection"}, "OSARA_PREVCCKEEPSEL", cmdMidiMoveToPreviousCCKeepSel},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous midi item on track"}, "OSARA_MIDIPREVITEM", cmdMidiMoveToPrevItem},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next midi item on track"}, "OSARA_MIDINEXTITEM", cmdMidiMoveToNextItem},
+	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Select all notes with the same pitch starting in time selection"}, "OSARA_SELSAMEPITCHTIMESEL", cmdMidiSelectSamePitchStartingInTimeSelection},
 #ifdef _WIN32
 	{MIDI_EVENT_LIST_SECTION, {DEFACCEL, "OSARA: Focus event nearest edit cursor"}, "OSARA_FOCUSMIDIEVENT", cmdFocusNearestMidiEvent},
 #endif


### PR DESCRIPTION
Adds an action "OSARA: Select all notes with the same pitch starting in time selection".  

This action has been requested, but I was a bit hesitant to do it as it is adding reaper functionality that is not strictly to do with accessibility. Sorry @ScottChesworth and @GianlucaApollaro, 6 months is more than a bit hesitant.:) However I suspect that selecting multiple notes is much easier with the mouse, so maybe this action does belong in Osara.  What do you think @jcsteh ? There are other actions in Osara for selecting notes.

Another thing that I am unsure about is weather to make this consistent with the action "Edit: Select all notes in time selection" which is currently on the keymap, or "Edit: Select all notes starting in time selection".  I think the latter makes more sense, so that is how I have implemented it.  I welcome comments regarding which way everyone thinks would be most useful.

I could of course do it both ways if they are both considered useful. 

in case anyone is unsure of the difference, "Edit: Select all notes in time selection" will include notes that are positioned before the start of the time selection if they are long enough to end within the time selection.  I think this is surprising behaviour.

