### PR TITLE
Add feedback for Take channel mode commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 #### Takes
 - Take: Switch items to next take: T
 - Take: Switch items to previous take: Shift+T
+- Item properties: Set take channel mode to normal: Shift+F5
+- Item properties: Set take channel mode to mono (left): Shift+F6
+- Item properties: Set take channel mode to mono (downmix): Shift+F7
+- Item properties: Set take channel mode to mono (right): Shift+F8
 
 #### Markers and Regions
 - Markers: Go to previous marker/project start: ;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1010,6 +1010,39 @@ void postToggleCountIn(int command) {
 	outputMessage(GetToggleCommandState(command) ? "count in on":"count in off");
 }
 
+void postTakeChannelMode(int command) {
+	int count = CountSelectedMediaItems(0);
+	if(count==0) {
+		outputMessage("no items selected");
+		return;
+	}
+	char* mode;
+	switch(command) {
+		case 40176: {
+			mode = "normal";
+			break;
+		}
+		case 40179: {
+			mode = "mono (left)";
+			break;
+		}
+		case 40178: {
+			mode = "mono (downmix)";
+			break;
+		}
+		case 40180: {
+			mode = "mono (right)";
+			break;
+		}
+		default: {
+			mode = "unknown mode";
+		}
+	}
+	ostringstream s;
+	s<< "set " << count <<((count==1)?" take ":" takes ") << "to " << mode;
+	outputMessage(s);
+}
+
 typedef void (*PostCommandExecute)(int);
 typedef struct PostCommand {
 	int cmd;
@@ -1124,6 +1157,10 @@ PostCommand POST_COMMANDS[] = {
 	{40406, postToggleTrackVolumeEnvelope}, // Track: Toggle track volume envelope visible
 	{40407, postToggleTrackPanEnvelope}, // Track: Toggle track pan envelope visible
 	{41819, postTogglePreRoll}, // Pre-roll: Toggle pre-roll on record
+	{40176, postTakeChannelMode}, // Item properties: Set take channel mode to normal
+	{40179, postTakeChannelMode}, // Item properties: Set take channel mode to mono (left)
+	{40178, postTakeChannelMode}, //Item properties: Set take channel mode to mono (downmix)
+	{40180, postTakeChannelMode}, // Item properties: Set take channel mode to mono (right)
 	{0},
 };
 PostCommand MIDI_POST_COMMANDS[] = {


### PR DESCRIPTION
- Item properties: Set take channel mode to normal
- Item properties: Set take channel mode to mono (left)
- Item properties: Set take channel mode to mono (downmix)
- Item properties: Set take channel mode to mono (right)