### PR TITLE
Fix issue where Osara doesn't always find stretch markers

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -783,7 +783,8 @@ int getStretchAtPos(MediaItem_Take* take, double pos, double itemStart,
 	// Stretch marker positions are relative to the start of the item and the
 	// take's play rate.
 	double posRel = (pos - itemStart) * playRate;
-	double posRelAdj = posRel-0.00003; // approximately 1 sample at 48000. 
+	const double STRETCH_FUZZ_FACTOR = 0.00003; // approximately 1 sample at 48000.
+	double posRelAdj = posRel - STRETCH_FUZZ_FACTOR;
 	if (posRelAdj < 0)
 		return -1;
 	int index = GetTakeStretchMarker(take, -1, &posRelAdj, NULL);
@@ -792,7 +793,7 @@ int getStretchAtPos(MediaItem_Take* take, double pos, double itemStart,
 	double stretchRel;
 	// Get the real position; pos wasn't written.
 	GetTakeStretchMarker(take, index, &stretchRel, NULL);
-	if (abs(stretchRel - posRel)>0.00003)
+	if (abs(stretchRel - posRel) > STRETCH_FUZZ_FACTOR)
 		return -1; // Marker not near to  pos.
 	return index;
 }

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -783,16 +783,17 @@ int getStretchAtPos(MediaItem_Take* take, double pos, double itemStart,
 	// Stretch marker positions are relative to the start of the item and the
 	// take's play rate.
 	double posRel = (pos - itemStart) * playRate;
-	if (posRel < 0)
+	double posRelAdj = posRel-0.00003; // approximately 1 sample at 48000. 
+	if (posRelAdj < 0)
 		return -1;
-	int index = GetTakeStretchMarker(take, -1, &posRel, NULL);
+	int index = GetTakeStretchMarker(take, -1, &posRelAdj, NULL);
 	if (index < 0)
 		return -1;
 	double stretchRel;
 	// Get the real position; pos wasn't written.
 	GetTakeStretchMarker(take, index, &stretchRel, NULL);
-	if (stretchRel != posRel)
-		return -1; // Marker not right at pos.
+	if (abs(stretchRel - posRel)>0.00003)
+		return -1; // Marker not near to  pos.
 	return index;
 }
 


### PR DESCRIPTION
In some cases, getStretchAtPos doesn't find the correct stretch marker, and instead finds the next stretch marker.  This causes "OSARA: Move last focused stretch marker to current edit cursor position" to fail.

This really feels like an ugly hack, but with the current Reaper API I can't see a better way of fixing it.  @jcsteh what do you think? 
