### PR TITLE
New mac installer

### DIFF
--- a/installer/mac/content/Install OSARA extension.command
+++ b/installer/mac/content/Install OSARA extension.command
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-target=~/"Library/Application Support/REAPER"
-cd "`dirname \"$0\"`/.data"
-cp reaper_osara.dylib "$target/UserPlugins"
-cp OSARA.ReaperKeyMap "$target/KeyMaps"
-echo Done.

--- a/installer/mac/content/Install OSARA.command
+++ b/installer/mac/content/Install OSARA.command
@@ -1,0 +1,58 @@
+#!/bin/bash
+osascript -l JavaScript - "`dirname \"$0\"`/.data/" << 'EOF'
+"use strict";
+var app = Application.currentApplication();
+app.includeStandardAdditions = true;
+var finder = Application("Finder");
+
+function isPortableReaper ( dir ) {
+	return (
+		finder.exists(Path(dir + "/REAPER64.app")) ||
+		finder.exists(Path(dir + "REAPER32.app")) )
+}
+
+function run(argv) {
+	var source = argv[0];
+	 var res = app.displayDialog("Choose weather to install Osara into a standard or a portable Reaper", {
+		buttons: ["Standard Reaper Installation", "Portable Reaper Installation", "Cancel"],
+		defaultButton: "Standard Reaper Installation",
+		cancelButton: "Cancel"
+	});
+	var portable = (res.buttonReturned === "Portable Reaper Installation");
+	var target;
+	if (portable === true) {
+		while(true) {
+			target = app.chooseFolder({
+				withPrompt:"Choose the folder containing your portable Reaper installation:"
+			});
+			if(isPortableReaper(target)) {
+				break;
+			} // user chose a folder that doesn't contain Reaper.
+			app.displayDialog("The folder you chose does not contain an installation of Reaper.");
+		}
+	} else {
+		target = app.pathTo("home folder") + "/Library/Application Support/REAPER"
+	}
+	target = target.toString();
+
+	var s = app.doShellScript;
+	try{
+		s(`mkdir '${target}/UserPlugins'`);
+	} catch (ignore){}// directory probably already exists
+	s(`cat '${source}/reaper_osara.dylib' > '${target}/UserPlugins/reaper_osara.dylib'`);
+	try{
+		s(`mkdir '${target}/KeyMaps'`);
+	} catch(ignore) {} // directory probably already exists
+	s(`cp '${source}/OSARA.ReaperKeyMap' '${target}/KeyMaps/'`);
+	var res = app.displayDialog(
+		"Do you want to replace the existing keymap with the Osara keymap?", {
+		buttons: ["Yes", "No"],
+		defaultButton: "Yes"});
+	if(res.buttonReturned==="Yes") {
+		try{
+			s(`cp '${target}/reaper-kb.ini' '${target}/KeyMaps/backup.ReaperKeyMap'`);
+		} catch(ignore) {} // there might not be a keymap to backup
+		s(`cp '${target}/KeyMaps/OSARA.ReaperKeyMap' '${target}/reaper-kb.ini'`);
+	}
+}
+EOF

--- a/installer/mac/content/Replace existing key map with OSARA key map.command
+++ b/installer/mac/content/Replace existing key map with OSARA key map.command
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-cd ~/"Library/Application Support/REAPER"
-cp KeyMaps/OSARA.ReaperKeyMap reaper-kb.ini
-echo Done.


### PR DESCRIPTION
I have implemented a gui installer for macOS.  It can handle portable Reaper installations, and it also optionally replaces the keymap. 

I know, it's a shell script containing javascript that calls shell commands.  it isn't pretty, but it works.  

I tried to make it an app compiled by osoacompile, but for some reason it was necessary to open the app twice before the security warning could be bypassed.  This way there is only one security warning.  

I also used cat to copy the dylib, which prevents it from having the quarantine bit.