### PR TITLE
feedback for volume commands plus set item end to source media end

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - (SWS extension) Xenakios/SWS: Select items under edit cursor on selected tracks: Shift+A
 - Item properties: Toggle mute: Alt+F5
 - Item: Open associated project in new tab
+- Item: Nudge items volume +1dB
+- Item: Nudge items volume -1dB
+- Xenakios/SWS: Nudge item volume down
+- Xenakios/SWS: Nudge item volume up
 
 #### Takes
 - Take: Switch items to next take: T
@@ -153,6 +157,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Item properties: Set take channel mode to mono (left): Shift+F6
 - Item properties: Set take channel mode to mono (downmix): Shift+F7
 - Item properties: Set take channel mode to mono (right): Shift+F8
+- Take: Nudge active takes volume +1dB
+- Take: Nudge active takes volume -1dB
+- Xenakios/SWS: Nudge active take volume down
+- Xenakios/SWS: Nudge active take volume up
 
 #### Markers and Regions
 - Markers: Go to previous marker/project start: ;

--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,7 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Item: Nudge items volume -1dB
 - Xenakios/SWS: Nudge item volume down
 - Xenakios/SWS: Nudge item volume up
+- Item: Set item end to source media end
 
 #### Takes
 - Take: Switch items to next take: T

--- a/src/osara.h
+++ b/src/osara.h
@@ -160,6 +160,7 @@
 #define REAPERAPI_WANT_Master_GetTempo
 #define REAPERAPI_WANT_CountTCPFXParms
 #define REAPERAPI_WANT_GetTCPFXParm
+#define REAPERAPI_WANT_GetMediaItemTakeInfo_Value
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1119,6 +1119,22 @@ void postTogglePreservePitchWhenPlayRateChanged(int command) {
 	outputMessage(s);
 }
 
+void postSetItemEnd(int command) {
+	MediaItem* item = getItemInContext();
+	if(item == nullptr)
+		return;
+	ostringstream s;
+	int selCount = CountSelectedMediaItems(0);
+	if(selCount > 1){
+		s << selCount << " item ends set to source media end";
+	} else {
+		double endPos = GetMediaItemInfo_Value(item, "D_POSITION") + GetMediaItemInfo_Value(item, "D_LENGTH");
+		s << "Item end set to source media end: ";
+		s << formatTime(endPos, TF_RULER, false, false, true);
+	}
+	outputMessage(s);
+}
+
 typedef void (*PostCommandExecute)(int);
 typedef struct PostCommand {
 	int cmd;
@@ -1253,6 +1269,7 @@ PostCommand POST_COMMANDS[] = {
 	{41924, postChangeItemVolume}, // Item: Nudge items volume -1dB
 	{41927, postChangeTakeVolume}, // Take: Nudge active takes volume +1dB
 	{41926, postChangeTakeVolume}, // Take: Nudge active takes volume -1dB
+	{40612, postSetItemEnd}, // Item: Set item end to source media end
 	{0},
 };
 PostCommand MIDI_POST_COMMANDS[] = {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -57,7 +57,7 @@ bool isSelectionContiguous = true;
 int lastCommand = 0;
 DWORD lastCommandTime = 0;
 int lastCommandRepeatCount;
-MediaItem* currentItem = NULL;
+MediaItem* currentItem = nullptr;
 
 
 /*** Utilities */
@@ -414,17 +414,16 @@ bool isTrackInClosedFolder(MediaTrack* track) {
 	return false;
 }
 
-MediaItem* getItemInContext() {
+MediaItem* getItemWithFocus() {
 	MediaItem* item;
 	// try to provide information based on the last item spoken by osara if it is selected
 	if (currentItem && ValidatePtr((void*)currentItem, "MediaItem*")
 		&& IsMediaItemSelected(currentItem)
 	) 
 	return currentItem;
-	else if(CountSelectedMediaItems(0)>0)
+	if(CountSelectedMediaItems(0)>0)
 		return GetSelectedMediaItem(0, 0);
-	else 
-		return nullptr;
+	return nullptr;
 }
 
 /*** Code to execute after existing actions.
@@ -696,16 +695,16 @@ void postChangeMasterTrackVolume(int command) {
 }
 
 void postChangeItemVolume(int command) {
-	MediaItem* item = getItemInContext();
-	if(item == nullptr)
+	MediaItem* item = getItemWithFocus();
+	if(!item)
 		return;
 	double volume = GetMediaItemInfo_Value(item, "D_VOL");
 	postChangeVolumeH(volume, command, "Item ");
 }
 
 void postChangeTakeVolume(int command) {
-	MediaItem* item = getItemInContext();
-	if(item == nullptr)
+	MediaItem* item = getItemWithFocus();
+	if(!item)
 		return;
 	MediaItem_Take* take = GetActiveTake(item);
 	double volume = GetMediaItemTakeInfo_Value(take, "D_VOL");
@@ -1120,8 +1119,8 @@ void postTogglePreservePitchWhenPlayRateChanged(int command) {
 }
 
 void postSetItemEnd(int command) {
-	MediaItem* item = getItemInContext();
-	if(item == nullptr)
+	MediaItem* item = getItemWithFocus();
+	if(!item)
 		return;
 	ostringstream s;
 	int selCount = CountSelectedMediaItems(0);
@@ -2089,8 +2088,8 @@ void cmdMoveItems(Command* command) {
 }
 
 void cmdMoveItemEdge(Command* command) {
-	MediaItem* item = getItemInContext();
-	if (item == nullptr) {
+	MediaItem* item = getItemWithFocus();
+	if (!item) {
 		outputMessage("No items selected");
 		Main_OnCommand(command->gaccel.accel.cmd, 0);
 		return;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -59,7 +59,6 @@ DWORD lastCommandTime = 0;
 int lastCommandRepeatCount;
 MediaItem* currentItem = nullptr;
 
-
 /*** Utilities */
 
 #ifdef _WIN32
@@ -707,6 +706,9 @@ void postChangeTakeVolume(int command) {
 	if(!item)
 		return;
 	MediaItem_Take* take = GetActiveTake(item);
+	if (!take) {
+		return;
+	}
 	double volume = GetMediaItemTakeInfo_Value(take, "D_VOL");
 	volume = fabs(volume);// volume is negative if take polarity is flipped
 	postChangeVolumeH(volume, command, "Take ");


### PR DESCRIPTION
Say track the first time  a track volume command is used to avoid confusion with item and take volume.
Implement feedback when changing item and take volume.

I would appreciate it if you could merge this before the new keymap, as the volume keys have changed and it will make getting used to the new keys easier.

@jcsteh  I changed lastCommand to int to allow it to be used in post commands.  I think the wrest of the Command struct is unused anyway. Is that correct or do you have something in mind for the future that requires lastCommand to be Command*?