### PR TITLE
implement noncontiguous selection for envelope points

### DIFF
--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -154,7 +154,9 @@ int countSelectedEnvelopePoints(TrackEnvelope* envelope, bool max2=false) {
 	return numSel;
 }
 
-void moveToEnvelopePoint(int direction, bool clearSelection=true) {
+int currentEnvelopePoint;
+
+void moveToEnvelopePoint(int direction, bool clearSelection=true, bool select = true) {
 	TrackEnvelope* envelope;
 	double offset;
 	tie(envelope, offset) = getSelectedEnvelopeAndOffset();
@@ -175,11 +177,7 @@ void moveToEnvelopePoint(int direction, bool clearSelection=true) {
 	bool selected;
 	GetEnvelopePointEx(envelope, currentAutomationItem, point, &time, &value, NULL, NULL, &selected);
 	time += offset;
-	if ((direction == 1 && time < now)
-		// If this point is at the cursor, skip it only if it's selected.
-		// This allows you to easily get to a point at the cursor
-		// while still allowing you to move beyond it once you do.
-		|| (direction == 1 && selected && time == now)
+	if ((direction == 1 && time <= now)
 		// Moving backward should skip the point at the cursor.
 		|| (direction == -1 && time >= now)
 	) {
@@ -194,9 +192,13 @@ void moveToEnvelopePoint(int direction, bool clearSelection=true) {
 	if (direction != 0 && direction == 1 ? time < now : time > now)
 		return; // No point in this direction.
 	fakeFocus = FOCUS_ENVELOPE;
-	if (clearSelection)
+	currentEnvelopePoint = point;
+	if (clearSelection) {
 		Main_OnCommand(40331, 0); // Envelope: Unselect all points
-	SetEnvelopePointEx(envelope, currentAutomationItem, point, NULL, NULL, NULL, NULL, &bTrue, &bTrue);
+		isSelectionContiguous = true;
+	}
+	if(select)
+		SetEnvelopePointEx(envelope, currentAutomationItem, point, NULL, NULL, NULL, NULL, &bTrue, &bTrue);
 	if (direction != 0)
 		SetEditCurPos(time, true, true);
 	ostringstream s;
@@ -204,14 +206,27 @@ void moveToEnvelopePoint(int direction, bool clearSelection=true) {
 	char out[64];
 	Envelope_FormatValue(envelope, value, out, sizeof(out));
 	s << out;
-	if (!clearSelection) {
+	bool isSelected;
+	GetEnvelopePointEx(envelope, currentAutomationItem, point, NULL, NULL, NULL, NULL, &isSelected);
+	if (isSelected) {
 		int numSel = countSelectedEnvelopePoints(envelope, true);
 		// One selected point is the norm, so don't report selected in this case.
 		if (numSel > 1)
 			s << " selected";
+	} else {
+		s << " unselected ";
 	}
 	s << " " << formatCursorPosition();
 	outputMessage(s);
+}
+
+bool toggleCurrentEnvelopePointSelection() {
+	TrackEnvelope* envelope = GetSelectedEnvelope(0);
+	bool isSelected;
+	GetEnvelopePointEx(envelope, currentAutomationItem, currentEnvelopePoint, NULL, NULL, NULL, NULL, &isSelected);
+	isSelected = !isSelected;
+	SetEnvelopePointEx(envelope, currentAutomationItem, currentEnvelopePoint, NULL, NULL, NULL, NULL, &isSelected, &bTrue);
+	return isSelected;
 }
 
 void cmdInsertEnvelopePoint(Command* command) {
@@ -358,19 +373,19 @@ void cmdSelectPreviousEnvelope(Command* command) {
 }
 
 void cmdMoveToNextEnvelopePoint(Command* command) {
-	moveToEnvelopePoint(1);
+	moveToEnvelopePoint(1, true, true);
 }
 
 void cmdMoveToPrevEnvelopePoint(Command* command) {
-	moveToEnvelopePoint(-1);
+	moveToEnvelopePoint(-1, true, true);
 }
 
 void cmdMoveToNextEnvelopePointKeepSel(Command* command) {
-	moveToEnvelopePoint(1, false);
+	moveToEnvelopePoint(1, false, isSelectionContiguous);
 }
 
 void cmdMoveToPrevEnvelopePointKeepSel(Command* command) {
-	moveToEnvelopePoint(-1, false);
+	moveToEnvelopePoint(-1, false, isSelectionContiguous);
 }
 
 void selectAutomationItem(TrackEnvelope* envelope, int index, bool select=true) {

--- a/src/envelopeCommands.h
+++ b/src/envelopeCommands.h
@@ -26,6 +26,7 @@ void cmdMoveToNextEnvelopePointKeepSel(Command* command);
 void cmdMoveToPrevEnvelopePointKeepSel(Command* command);
 void moveToAutomationItem(int direction, bool clearSelection=true, bool select=true);
 bool toggleCurrentAutomationItemSelection();
+bool toggleCurrentEnvelopePointSelection();
 void reportCopiedEnvelopePointsOrAutoItems();
 void postToggleTrackVolumeEnvelope(int command);
 void postToggleTrackPanEnvelope(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2370,6 +2370,9 @@ void cmdToggleSelection(Command* command) {
 		case FOCUS_AUTOMATIONITEM:
 			select = toggleCurrentAutomationItemSelection();
 			break;
+		case FOCUS_ENVELOPE:
+			select = toggleCurrentEnvelopePointSelection();
+			break;
 		default:
 			return;
 	}


### PR DESCRIPTION
This allows non-contiguous selection of envelope points in the same way as for tracks and items.