### PR TITLE
Fix C++ production quality warnings.

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -18,7 +18,7 @@ sources = [
 ]
 
 if env["PLATFORM"] == "win32":
-	env.Append(CPPFLAGS="/EHsc /std:c++latest")
+	env.Append(CXXFLAGS="/EHsc /std:c++latest /W3 /WX")
 	# We always want debug symbols.
 	env.Append(PDB="${TARGET}.pdb")
 	# having symbols usually turns this off, but we have no need for unused symbols.
@@ -41,12 +41,16 @@ else: # Mac
 	swellDir = env.Dir("#include/WDL/WDL/swell")
 	env.Append(CPPPATH=(swellDir,))
 	env["CXX"] = "clang++"
-	env.Append(CXXFLAGS=("-stdlib=libc++", "-std=c++17"))
+	cxxFlags = "-stdlib=libc++ -std=c++17 -Werror"
+	env.Append(CXXFLAGS=cxxFlags)
 	# SWELL files.
-	sources.extend(swellDir.File(f) for f in (
-		"swell.cpp", "swell-ini.cpp", "swell-dlg.mm", "swell-gdi.mm",
-		"swell-kb.mm", "swell-misc.mm", "swell-miscdlg.mm", "swell-menu.mm",
-		"swell-wnd.mm", "swell-modstub.mm",
+	sources.extend(
+		# Disable warnings for SWELL, since we don't have any control over those.
+		env.SharedObject(swellDir.File(f), CXXFLAGS=cxxFlags + "-Wno-everything")
+		for f in (
+			"swell.cpp", "swell-ini.cpp", "swell-dlg.mm", "swell-gdi.mm",
+			"swell-kb.mm", "swell-misc.mm", "swell-miscdlg.mm", "swell-menu.mm",
+			"swell-wnd.mm", "swell-modstub.mm",
 	))
 	sources.append("osxa11y.mm")
 	libs = []

--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -515,7 +515,7 @@ void reportCopiedEnvelopePointsOrAutoItems() {
 	}
 	ostringstream s;
 	int count;
-	if (count = countSelectedAutomationItems(envelope)) {
+	if ((count = countSelectedAutomationItems(envelope))) {
 		s << count << (count == 1 ? " automation item" : " automation items");
 	} else {
 		count = countSelectedEnvelopePoints(envelope);
@@ -533,12 +533,13 @@ bool isEnvelopeVisible(TrackEnvelope* envelope) {
 	return !m.empty() && m.str(4)[0] == '1';
 }
 
-void reportToggleTrackEnvelope(char* envType) {
+void reportToggleTrackEnvelope(const char* envType) {
 	MediaTrack* track = GetLastTouchedTrack();
 	if (!track) {
 		return;
 	}
-	auto envelope = (TrackEnvelope*)GetSetMediaTrackInfo(track, "P_ENV", envType);
+	auto envelope = (TrackEnvelope*)GetSetMediaTrackInfo(track, "P_ENV",
+		(void*)envType);
 	bool visible = envelope && isEnvelopeVisible(envelope);
 	ostringstream s;
 	s << (visible ? "showed " : "hid ");

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -197,7 +197,8 @@ void previewNotes(MediaItem_Take* take, const vector<MidiNote>& notes) {
 	// Calculate the minimum note length.
 	double minLength = min_element(notes.begin(), notes.end(), compareNotesByLength)->getLength();
 	// Schedule note off messages.
-	previewDoneTimer = SetTimer(NULL, NULL, max(DEFAULT_PREVIEW_LENGTH, (minLength * 1000)), previewDone);
+	previewDoneTimer = SetTimer(nullptr, 0,
+		(UINT)max(DEFAULT_PREVIEW_LENGTH, (minLength * 1000)), previewDone);
 }
 
 void cmdMidiMoveCursor(Command* command) {
@@ -227,7 +228,7 @@ void cmdMidiMoveCursor(Command* command) {
 }
 
 const string getMidiNoteName(MediaItem_Take *take, int pitch, int channel) {
-	static char* names[] = {"c", "c sharp", "d", "d sharp", "e", "f",
+	static const char* names[] = {"c", "c sharp", "d", "d sharp", "e", "f",
 		"f sharp", "g", "g sharp", "a", "a sharp", "b"};
 	MediaTrack* track = GetMediaItemTake_Track(take);
 	int tracknumber = static_cast<int> (GetMediaTrackInfo_Value(track, "IP_TRACKNUMBER")); // one based
@@ -328,9 +329,10 @@ MidiNote findNoteInChord(MediaItem_Take* take, int direction) {
 		notes.push_back({chan, pitch, vel, note, start, end});
 	}
 	sort(notes.begin(), notes.end(), compareNotesByPitch);
-	const int lastNoteIndex = notes.size() - 1;
+	const int lastNoteIndex = (int)notes.size() - 1;
 	// Work out which note to move to.
-	if (direction != 0 && 0 <= curNoteInChord && curNoteInChord <= lastNoteIndex) {
+	if (direction != 0 && 0 <= curNoteInChord &&
+			curNoteInChord <= (int)lastNoteIndex) {
 		// Already on a note within the chord. Move to the next/previous note.
 		curNoteInChord += direction;
 		// If we were already on the first/last note, stay there.
@@ -338,7 +340,7 @@ MidiNote findNoteInChord(MediaItem_Take* take, int direction) {
 			curNoteInChord -= direction;
 	} else if (direction != 0) {
 		// We're moving into a new chord. Move to the first/last note.
-		curNoteInChord = direction == 1 ? 0 : lastNoteIndex;
+		curNoteInChord = direction == 1 ? 0 : (int)lastNoteIndex;
 	}
 	return notes[curNoteInChord];
 }
@@ -480,6 +482,8 @@ void cmdMidiToggleSelection(Command* command) {
 			selectCC(take, currentCC, select);
 			break;
 		}
+		default:
+			return;
 	}
 	outputMessage(select ? "selected" : "unselected");
 }

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -110,7 +110,7 @@ class ReaperObjParamSource: public ParamSource {
 	public:
 
 	int getParamCount() {
-		return this->params.size();
+		return (int)this->params.size();
 	}
 
 	string getParamName(int param) {
@@ -464,7 +464,7 @@ class ParamsDialog {
 			this->visibleParams.push_back(p);
 			ComboBox_AddString(this->paramCombo, name.c_str());
 			if (p == prevSelParam)
-				newComboSel = this->visibleParams.size() - 1;
+				newComboSel = (int)this->visibleParams.size() - 1;
 		}
 		ComboBox_SetCurSel(this->paramCombo, newComboSel);
 		if (this->visibleParams.empty()) {
@@ -879,7 +879,7 @@ FxList listFx(MediaItem_Take* track) {
 template<typename ReaperObj>
 void fxParams_begin(ReaperObj* obj, const string& apiPrefix) {
 	const auto fxList = listFx(obj);
-	const int fxCount = fxList.size();
+	const size_t fxCount = fxList.size();
 	int fx = -1;
 	if (fxCount == 0) {
 		outputMessage("No FX");
@@ -891,13 +891,13 @@ void fxParams_begin(ReaperObj* obj, const string& apiPrefix) {
 		HMENU effects = CreatePopupMenu();
 		MENUITEMINFO itemInfo;
 		itemInfo.cbSize = sizeof(MENUITEMINFO);
-		for (int f = 0; f < fxCount; ++f) {
+		for (size_t f = 0; f < fxCount; ++f) {
 			itemInfo.fMask = MIIM_TYPE | MIIM_ID;
 			itemInfo.fType = MFT_STRING;
 			itemInfo.wID = fxList[f].first + 1;
 			itemInfo.dwTypeData = (char*)fxList[f].second.c_str();
-			itemInfo.cch = fxList[f].second.length();
-			InsertMenuItem(effects, f, true, &itemInfo);
+			itemInfo.cch = (UINT)fxList[f].second.length();
+			InsertMenuItem(effects, (UINT)f, true, &itemInfo);
 		}
 		fx = TrackPopupMenu(effects, TPM_NONOTIFY | TPM_RETURNCMD, 0, 0, 0, mainHwnd, NULL) - 1;
 		DestroyMenu(effects);

--- a/src/peakWatcher.cpp
+++ b/src/peakWatcher.cpp
@@ -237,8 +237,9 @@ void cmdPeakWatcher(Command* command) {
 				s << "current ";
 			s << (int)(size_t)GetSetMediaTrackInfo(track, "IP_TRACKNUMBER", NULL);
 			char* name;
-			if (name = (char*)GetSetMediaTrackInfo(track, "P_NAME", NULL))
+			if ((name = (char*)GetSetMediaTrackInfo(track, "P_NAME", nullptr))) {
 				s << ": " << name;
+			}
 			ComboBox_AddString(trackSel, s.str().c_str());
 			s.str("");
 			if (!pwTrack.follow && pwTrack.track == track)

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -13,10 +13,13 @@
 #include <Windowsx.h>
 #include <Commctrl.h>
 #endif
+// Must be defined before any C++ STL header is included.
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <string>
 #include <sstream>
 #include <map>
 #include <iomanip>
+#include <cassert>
 #include <math.h>
 #include <optional>
 #ifdef _WIN32
@@ -180,7 +183,7 @@ string formatTime(double time, TimeFormat format, bool isLength, bool useCache, 
 		}
 		case TF_MINSEC: {
 			// Minutes:seconds
-			int minute = time / 60;
+			int minute = (int)(time / 60);
 			time = fmod(time, 60);
 			if (!useCache || oldMinute != minute) {
 				s << minute << " min ";
@@ -198,7 +201,7 @@ string formatTime(double time, TimeFormat format, bool isLength, bool useCache, 
 		}
 		case TF_FRAME: {
 			// Frames
-			int frame = time * TimeMap_curFrameRate(0, NULL);
+			int frame = (int)(time * TimeMap_curFrameRate(0, nullptr));
 			if (!useCache || oldFrame != frame) {
 				s << frame << (frame == 1 ? " frame" : " frames");
 				oldFrame = frame;
@@ -207,25 +210,25 @@ string formatTime(double time, TimeFormat format, bool isLength, bool useCache, 
 		}
 		case TF_HMSF: {
 			// Hours:minutes:seconds:frames
-			int hour = time / 3600;
+			int hour = (int)(time / 3600);
 			time = fmod(time, 3600);
 			if (!useCache || oldHour != hour) {
 				s << hour << (hour == 1 ? " hour " : " hours ");
 				oldHour = hour;
 			}
-			int minute = time / 60;
+			int minute = (int)(time / 60);
 			time = fmod(time, 60);
 			if (!useCache || oldMinute != minute) {
 				s << minute << " min ";
 				oldMinute = minute;
 			}
-			int second = time;
+			int second = (int)time;
 			if (!useCache || oldSecond != second) {
 				s << second << " sec ";
 				oldSecond = second;
 			}
 			time = time - second;
-			int frame = time * TimeMap_curFrameRate(0, NULL);
+			int frame = (int)(time * TimeMap_curFrameRate(0, NULL));
 			if (!useCache || oldFrame != frame) {
 				s << frame << (frame == 1 ? " frame" : " frames");
 				oldFrame = frame;
@@ -238,6 +241,8 @@ string formatTime(double time, TimeFormat format, bool isLength, bool useCache, 
 			s << buf << " samples";
 			break;
 		}
+		default:
+			assert(false);
 	}
 	// #31: Clear cache for other units to avoid confusion if they are used later.
 	resetTimeCache(format);
@@ -415,7 +420,6 @@ bool isTrackInClosedFolder(MediaTrack* track) {
 }
 
 MediaItem* getItemWithFocus() {
-	MediaItem* item;
 	// try to provide information based on the last item spoken by osara if it is selected
 	if (currentItem && ValidatePtr((void*)currentItem, "MediaItem*")
 		&& IsMediaItemSelected(currentItem)
@@ -669,7 +673,7 @@ void postGoToSpecificMarker(int command) {
 	}
 }
 
-void postChangeVolumeH(double volume, int command, char* commandMessage) {
+void postChangeVolumeH(double volume, int command, const char* commandMessage) {
 	ostringstream s;
 	if(lastCommand != command) 
 		s << commandMessage;
@@ -1073,7 +1077,7 @@ void postTakeChannelMode(int command) {
 		outputMessage("no items selected");
 		return;
 	}
-	char* mode;
+	const char* mode;
 	switch(command) {
 		case 40176: {
 			mode = "normal";
@@ -1399,6 +1403,8 @@ bool showReaperContextMenu(const int menu) {
 			ShowPopupMenu("envelope_item", 0, 0, nullptr, nullptr,
 				currentAutomationItem + 1, 0);
 			return true;
+		default:
+			break;
 	}
 	return false;
 }
@@ -2337,6 +2343,8 @@ void cmdReportSelection(Command* command) {
 			}
 			break;
 		}
+		default:
+			return;
 	}
 	if (count == 0)
 		s << "No selection";
@@ -3117,7 +3125,7 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		surface = createSurface();
 		rec->Register("csurf_inst", (void*)surface);
 		registerExports(rec);
-		SetTimer(NULL, NULL, 0, delayedInit);
+		SetTimer(nullptr, 0, 0, delayedInit);
 #ifdef _WIN32
 		keyboardHook = SetWindowsHookEx(WH_KEYBOARD, keyboardHookProc, NULL, guiThread);
 #endif


### PR DESCRIPTION
1. Use /W3 C++ warning level on Windows.
2. Fix all warnings from both clang and cl.
3. Treat warnings as errors in future.

Fixes #321.