### PR TITLE
Expose osara_isShortcutHelpEnabled function to C++.

### DIFF
--- a/src/exports.cpp
+++ b/src/exports.cpp
@@ -19,6 +19,10 @@ void* _vararg_osara_outputMessage(void** args, int nArgs) {
 	return nullptr;
 }
 
+bool osara_isShortcutHelpEnabled() {
+	return isShortcutHelpEnabled;
+}
+
 void registerExports(reaper_plugin_info_t* rec) {
 	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
 	rec->Register("APIvararg_osara_outputMessage",
@@ -29,4 +33,6 @@ void registerExports(reaper_plugin_info_t* rec) {
 		"This should only be used in consultation with screen reader users. "
 		"Note that this may not work on Windows when certain GUI controls have "
 		"focus such as list boxes and trees.");
+	rec->Register("API_osara_isShortcutHelpEnabled",
+		(void*)osara_isShortcutHelpEnabled);
 }

--- a/src/osara.h
+++ b/src/osara.h
@@ -183,6 +183,7 @@ typedef struct Command {
 } Command;
 extern int lastCommandRepeatCount;
 extern DWORD lastCommandTime;
+extern bool isShortcutHelpEnabled;
 
 extern HINSTANCE pluginHInstance;
 extern HWND mainHwnd;


### PR DESCRIPTION
Hooks are run in the order they're registered and OSARA might be loaded after other extensions.
This allows other extensions (specifically SWS for now) to query when OSARA shortcut help is enabled and let the action through to OSARA in that case.
Fixes #359.