### PR TITLE
Add feedback for move notes left/right one grid unit/pixel actions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,10 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Edit: Shorten notes one pixel: Alt+NumPad1 or Alt+Shift+L
 - Edit: Lengthen notes one grid unit: NumPad3 or L
 - Edit: Shorten notes one grid unit: NumPad1 or Shift+L
+- Edit: Move notes left one pixel: Alt+NumPad4 or Alt+Shift+P
+- Edit: Move notes right one pixel: Alt+NumPad6 or Alt+P
+- Edit: Move notes left one grid unit: NumPad4 or Shift+P
+- Edit: Move notes right one grid unit: NumPad6 or P
 - Edit: Note velocity +01: NumPad9 or V
 - Edit: Note velocity +10: Alt+NumPad9 or Alt+V
 - Edit: Note velocity -01: NumPad7 or Shift+V

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1123,7 +1123,7 @@ void postMidiChangePitch(int command) {
 
 void postMidiMoveStart(int command) {
 	HWND editor = MIDIEditor_GetActive();
-	MediaItem_Take* take = MIDIEditor_GetTake(editor);	
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	// Get selected notes.
 	vector<MidiNote> selectedNotes = getSelectedNotes(take);
 	auto count = selectedNotes.size();

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -38,5 +38,6 @@ void cmdMidiFilterWindow(Command* command);
 void postMidiChangeVelocity(int command);
 void postMidiChangeLength(int command);
 void postMidiChangePitch(int command);
+void postMidiMoveStart(int command);
 void postMidiChangeCCValue(int command);
 void postMidiSwitchCCLane(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1521,6 +1521,10 @@ PostCommand MIDI_POST_COMMANDS[] = {
 	{40178, postMidiChangePitch}, // Edit: Move notes down one semitone
 	{40179, postMidiChangePitch}, // Edit: Move notes up one octave
 	{40180, postMidiChangePitch}, // Edit: Move notes down one octave
+	{40181, postMidiMoveStart}, // Edit: Move notes left one pixel
+	{40182, postMidiMoveStart}, // Edit: Move notes right one pixel
+	{40183, postMidiMoveStart}, // Edit: Move notes left one grid unit
+	{40184, postMidiMoveStart}, // Edit: Move notes right one grid unit
 	{40187, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one octave
 	{40188, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one octave
 	{40234, postMidiSwitchCCLane}, // CC: Next CC lane


### PR DESCRIPTION
Note that moving notes horizontally doesn't change the cursor position, therefore the generalisation behavior is somewhat different from the change pitch / length actions.