### PR TITLE
Add feedback for Edit: Move edit cursor left/right one pixel and add note previews

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -325,6 +325,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 #### MIDI Editor
 - View: Go to start of file: Control+Home
 - View: Go to end of file: Control+End
+- Edit: Move edit cursor right one pixel: Alt+RightArrow or Control+Alt+Numpad6
+- Edit: Move edit cursor left one pixel: Alt+LeftArrow or Control+Alt+Numpad4
 - Edit: Move edit cursor right by grid: Alt+Shift+RightArrow or Control+Numpad6
 - Edit: Move edit cursor left by grid: Alt+Shift+LeftArrow or Control+Numpad4
 - Navigate: Move edit cursor right one measure: PageDown

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -216,15 +216,18 @@ void cmdMidiMoveCursor(Command* command) {
 		double start;
 		MIDI_GetNote(take, n, NULL, NULL, &start, NULL, NULL, NULL, NULL);
 		start = MIDI_GetProjTimeFromPPQPos(take, start);
-		if (start > now)
+		if (start > now) {
 			break;
-		if (start == now)
+		}
+		if (start == now) {
 			++count;
+		}
 	}
-	if (count > 0)
+	if (count > 0) {
 		fakeFocus = FOCUS_NOTE;
 		s << " " << count << (count == 1 ? " note" : " notes");
-		outputMessage(s);
+	}
+	outputMessage(s);
 }
 
 const string getMidiNoteName(MediaItem_Take *take, int pitch, int channel) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3079,6 +3079,8 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0, 40037}, NULL}, NULL, cmdMidiMoveCursor}, // View: Go to end of file
 	{MIDI_EDITOR_SECTION, {{0, 0, 40047}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor left by grid
 	{MIDI_EDITOR_SECTION, {{0, 0, 40048}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor right by grid
+	{MIDI_EDITOR_SECTION, {{0, 0, 40185}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor left one pixel
+	{MIDI_EDITOR_SECTION, {{0, 0, 40186}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor right one pixel
 	{MIDI_EDITOR_SECTION, {{0, 0, 40682}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor right one measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40683}, NULL}, NULL, cmdMidiMoveCursor}, // Edit: Move edit cursor left one measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40667}, NULL}, NULL, cmdMidiDeleteEvents}, // Edit: Delete events


### PR DESCRIPTION
This does the following:

* Add feedback for Edit: Move edit cursor left/right one pixel
* fixes wrong use of braces where 0 notes were announced incorrectly
* Added note preview when moving cursor one grid unit/pixel