### PR TITLE
Fix to midi editor action id mistakes

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1094,11 +1094,11 @@ void postMidiChangePitch(int command) {
 			case 40178:
 				s << "semitone down";
 				break;
+			case 40179:
+				s << "octave up";
+				break;
 			case 40180:
 				s << "octave down";
-				break;
-			case 40181:
-				s << "octave up";
 				break;
 			case 41026:
 				s << "semitone up ignoring scale";

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1529,7 +1529,7 @@ PostCommand MIDI_POST_COMMANDS[] = {
 	{40188, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one octave
 	{40234, postMidiSwitchCCLane}, // CC: Next CC lane
 	{40235, postMidiSwitchCCLane}, // CC: Previous CC lane
-	{40435, postMidiSelectNotes}, // Select all notes with the same pitch
+	{40434, postMidiSelectNotes}, // Select all notes with the same pitch
 	{40444, postMidiChangeLength}, // Edit: Lengthen notes one pixel
 	{40445, postMidiChangeLength}, // Edit: Shorten notes one pixel
 	{40446, postMidiChangeLength}, // Edit: Lengthen notes one grid unit


### PR DESCRIPTION
1. The announcement for select notes with the same pitch was attached to the all notes off action
2. We were using the wrong action id for the generalisation of the one octave up action.