### PR TITLE
Add action feedback for moving to the start of current measure, start of next measure and beginning/end of loop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - View: Move cursor right one pixel: Rightarrow
 - Transport: Go to start of project: Control+Home
 - Transport: Go to end of project: Control+End
+- Move edit cursor to start of next measure: Alt+End
+- Move edit cursor to start of current measure: Alt+Home
 - Go forward one measure: PageDown
 - Go back one measure: PageUp
 - Go forward one beat: Control+PageDown
@@ -266,6 +268,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Time selection: Set end point: ]
 - Loop points: Set start point: Alt+Shift+[
 - Loop points: Set end point: Alt+Shift+]
+- Go to start of loop: Alt+Shift+Home
+- Go to end of loop: Alt+Shift+End
 - Time selection: Remove contents of time selection (moving later items)
 - Time selection: Remove time selection and loop point selection: Escape
 - Unselect all tracks/items/envelope points: Shift+Escape

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1389,6 +1389,8 @@ PostCommand POST_COMMANDS[] = {
 	{40319, postCursorMovement}, // Item navigation: Move cursor right to edge of item
 	{40646, postCursorMovement}, // View: Move cursor left to grid division
 	{40647, postCursorMovement}, // View: Move cursor right to grid division
+	{41040, postCursorMovement}, // Move edit cursor to start of next measure
+	{41041, postCursorMovement}, // Move edit cursor to start of current measure
 	{41042, postCursorMovement}, // Go forward one measure
 	{41043, postCursorMovement}, // Go back one measure
 	{41044, postCursorMovement}, // Go forward one beat
@@ -1497,6 +1499,8 @@ PostCommand POST_COMMANDS[] = {
 	{40612, postSetItemEnd}, // Item: Set item end to source media end
 	{40630, postCursorMovement}, // Go to start of time selection
 	{40631, postCursorMovement}, // Go to end of time selection
+	{40632, postCursorMovement}, // Go to start of loop
+	{40633, postCursorMovement}, // Go to end of loop
 	{40032, postChangeItemGroup}, // Item grouping: Group items
 	{40033, postChangeItemGroup}, // Item grouping: Remove items from group
 	{42393, postGoToTakeMarker}, // Item: Set cursor to previous take marker in selected items


### PR DESCRIPTION
There you go @ScottChesworth. I assume this is what you expect to happen for these actions?

Fixes #404