### PR TITLE
Ensure move to next/previous cc doesn't end up at unexisting cc

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -779,6 +779,9 @@ void moveToCC(int direction, bool clearSelection=true, bool select=true, bool us
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	auto cc = findCC(take, direction);
+	if (cc.channel == -1) {
+		return;
+	}
 	if (clearSelection || select) {
 		Undo_BeginBlock();
 	}


### PR DESCRIPTION
The move to previous/next cc actions weren't checking the result of findCC correctly, causing reporting and moving to unexisting ccs.