### PR TITLE
Play note preview in event list when note gets focus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -588,6 +588,9 @@ Noncontiguous selection is also possible.
 You do this in the same way described above for tracks and items.
 That is, press shift+space (OSARA: Enable noncontiguous selection/toggle selection of current chord/note) to switch to noncontiguous selection, move to other chords/notes with shift plus the arrow keys and press shift+space to select/unselect the current chord/note.
 
+#### Note preview in de event list (Windows Only)
+When the MIDI Editor is set to Event List mode, REAPER presents a list with all the events in the current MIDI item. When a note gets focus in the list, OSARA will play a preview of the respective note.
+
 ### Navigating FX Presets Without Activating Them (Windows Only)
 REAPER's FX preset combo box doesn't allow keyboard users to move through presets without activating them.
 Sometimes, you need to be able to examine the presets without activating each one.

--- a/readme.md
+++ b/readme.md
@@ -588,8 +588,9 @@ Noncontiguous selection is also possible.
 You do this in the same way described above for tracks and items.
 That is, press shift+space (OSARA: Enable noncontiguous selection/toggle selection of current chord/note) to switch to noncontiguous selection, move to other chords/notes with shift plus the arrow keys and press shift+space to select/unselect the current chord/note.
 
-#### Note preview in de event list (Windows Only)
-When the MIDI Editor is set to Event List mode, REAPER presents a list with all the events in the current MIDI item. When a note gets focus in the list, OSARA will play a preview of the respective note.
+### Note Preview in the MIDI Event List (Windows Only)
+When the MIDI Editor is set to Event List mode, REAPER presents a list with all the events in the current MIDI item.
+When a note gets focus in the list, OSARA will play a preview of the focused note.
 
 ### Navigating FX Presets Without Activating Them (Windows Only)
 REAPER's FX preset combo box doesn't allow keyboard users to move through presets without activating them.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1000,7 +1000,7 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 	// Get the text from the length column (2).
 	// If this column is empty, we aren't dealing with a note.
 	ListView_GetItemText(hwnd, focused, 2, text, sizeof(text));
-	if (strcmp(text, "\0") == 0) {
+	if (!text[0]) {
 		return;
 	}
 	MidiNote note;

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -996,29 +996,27 @@ void cmdMidiFilterWindow(Command *command) {
 
 void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 	auto focused = ListView_GetNextItem(hwnd, -1, LVNI_FOCUSED);
-	char text[50];
-	// Get the text from the type column (4).
-	ListView_GetItemText(hwnd, focused, 4, text, sizeof(text));
-	if (strcmp(text, "Note") != 0) {
+	char text[50] = "\0";
+	// Get the text from the length column (2).
+	// If this column is empty, we aren't dealing with a note.
+	ListView_GetItemText(hwnd, focused, 2, text, sizeof(text));
+	if (strcmp(text, "\0") == 0) {
 		return;
 	}
-	fill(begin(text), end(text), 0);
 	MidiNote note;
+	// Convert length to project time. text is always in measures.beats.
+	auto length = parse_timestr_len(text, 0, 2);
+	text[0] = '\0';
 	// Get the text from the position column (1).
 	ListView_GetItemText(hwnd, focused, 1, text, sizeof(text));
 	// Convert this to project time. text is always in measures.beats.
 	note.start = parse_timestr_pos(text, 2);
-	fill(begin(text), end(text), 0);
-	// Get the text from the length column (2).
-	ListView_GetItemText(hwnd, focused, 2, text, sizeof(text));
-	// Convert this to project time. text is always in measures.beats.
-	auto length = parse_timestr_len(text, 0, 2);
 	note.end = note.start + length;
-	fill(begin(text), end(text), 0);
+	text[0] = '\0';
 	// Get the text from the channel column (3).
 	ListView_GetItemText(hwnd, focused, 3, text, sizeof(text));
 	note.channel = atoi(text);
-	fill(begin(text), end(text), 0);
+	text[0] = '\0';
 	// Get the text from the parameter (note name) column (5).
 	ListView_GetItemText(hwnd, focused, 5, text, sizeof(text));
 	string noteNameWithOctave { text };
@@ -1034,7 +1032,7 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 		note.pitch = ((octave + 1) * 12) + i;
 		break;
 	}
-	fill(begin(text), end(text), 0);
+	text[0] = '\0';
 	// Get the text from the value (velocity) column (6).
 	ListView_GetItemText(hwnd, focused, 6, text, sizeof(text));
 	note.velocity = atoi(text);

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1023,14 +1023,23 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 	static const string noteNames[] = {"C", "C#", "D", "D#", "E", "F",
 		"F#", "G", "G#", "A", "A#", "B"};
 	// Loop through noteNames in reverse order so the sharp notes are handled first.
+	bool found = false;
 	for (int i = static_cast<int>(size(noteNames)) -1; i >= 0; --i) {
 		auto noteNameLength = noteNames[i].length();
 		if (noteNameWithOctave.compare(0, noteNameLength, noteNames[i]) != 0) {
 			continue;
 		}
-		int octave = stoi(noteNameWithOctave.substr(noteNameLength, string::npos));
+		found = true;
+		// The octave is a number in the range -1 up and until 9.
+		// Therefore, the number counts either one or two characters in noteNameWithOctave.
+		// If the note is explicitly named, the name comes after the octave and a space.
+		// As stoi simply ignores whitespace or the end of a string, all possible appearances should be covered.
+		int octave = stoi(noteNameWithOctave.substr(noteNameLength, 2));
 		note.pitch = ((octave + 1) * 12) + i;
 		break;
+	}
+	if (!found) {
+		return; // Note not found.
 	}
 	text[0] = '\0';
 	// Get the text from the value (velocity) column (6).

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -994,6 +994,55 @@ void cmdMidiFilterWindow(Command *command) {
 	}
 }
 
+void maybePreviewCurrentNoteInEventList(HWND hwnd) {
+	auto focused = ListView_GetNextItem(hwnd, -1, LVNI_FOCUSED);
+	char text[50];
+	// Get the text from the type column (4).
+	ListView_GetItemText(hwnd, focused, 4, text, sizeof(text));
+	if (strcmp(text, "Note") != 0) {
+		return;
+	}
+	fill(begin(text), end(text), 0);
+	MidiNote note;
+	// Get the text from the position column (1).
+	ListView_GetItemText(hwnd, focused, 1, text, sizeof(text));
+	// Convert this to project time. text is always in measures.beats.
+	note.start = parse_timestr_pos(text, 2);
+	fill(begin(text), end(text), 0);
+	// Get the text from the length column (2).
+	ListView_GetItemText(hwnd, focused, 2, text, sizeof(text));
+	// Convert this to project time. text is always in measures.beats.
+	auto length = parse_timestr_len(text, 0, 2);
+	note.end = note.start + length;
+	fill(begin(text), end(text), 0);
+	// Get the text from the channel column (3).
+	ListView_GetItemText(hwnd, focused, 3, text, sizeof(text));
+	note.channel = atoi(text);
+	fill(begin(text), end(text), 0);
+	// Get the text from the parameter (note name) column (5).
+	ListView_GetItemText(hwnd, focused, 5, text, sizeof(text));
+	string noteNameWithOctave { text };
+	static const string noteNames[] = {"C", "C#", "D", "D#", "E", "F",
+		"F#", "G", "G#", "A", "A#", "B"};
+	// Loop through noteNames in reverse order so the sharp notes are handled first.
+	for (int i = static_cast<int>(size(noteNames)) -1; i >= 0; --i) {
+		auto noteNameLength = noteNames[i].length();
+		if (noteNameWithOctave.compare(0, noteNameLength, noteNames[i]) != 0) {
+			continue;
+		}
+		int octave = stoi(noteNameWithOctave.substr(noteNameLength, string::npos));
+		note.pitch = ((octave + 1) * 12) + i;
+		break;
+	}
+	fill(begin(text), end(text), 0);
+	// Get the text from the value (velocity) column (6).
+	ListView_GetItemText(hwnd, focused, 6, text, sizeof(text));
+	note.velocity = atoi(text);
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	previewNotes(take, {note});
+}
+
 #endif // _WIN32
 
 void postMidiChangeVelocity(int command) {

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -40,6 +40,7 @@ void cmdMidiNoteSplitOrJoin(Command* command);
 #ifdef _WIN32
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);
+void maybePreviewCurrentNoteInEventList(HWND hwnd);
 #endif
 
 void postMidiChangeVelocity(int command);

--- a/src/osara.h
+++ b/src/osara.h
@@ -14,6 +14,7 @@
 #include <sstream>
 
 #define REAPERAPI_MINIMAL
+#define REAPERAPI_WANT_ShowConsoleMsg
 #define REAPERAPI_WANT_GetLastTouchedTrack
 #define REAPERAPI_WANT_GetSetMediaTrackInfo
 #define REAPERAPI_WANT_TimeMap2_timeToBeats
@@ -45,6 +46,7 @@
 #define REAPERAPI_WANT_Main_OnCommand
 #define REAPERAPI_WANT_Undo_CanUndo2
 #define REAPERAPI_WANT_Undo_CanRedo2
+#define REAPERAPI_WANT_parse_timestr_len
 #define REAPERAPI_WANT_parse_timestr_pos
 #define REAPERAPI_WANT_GetMasterTrackVisibility
 #define REAPERAPI_WANT_SetMasterTrackVisibility

--- a/src/osara.h
+++ b/src/osara.h
@@ -14,7 +14,6 @@
 #include <sstream>
 
 #define REAPERAPI_MINIMAL
-#define REAPERAPI_WANT_ShowConsoleMsg
 #define REAPERAPI_WANT_GetLastTouchedTrack
 #define REAPERAPI_WANT_GetSetMediaTrackInfo
 #define REAPERAPI_WANT_TimeMap2_timeToBeats

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3357,8 +3357,7 @@ void CALLBACK handleWinEvent(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG ob
 			annotateAccRole(hwnd, ROLE_SYSTEM_PANE);
 		}
 
-		bool focusIsMidiEditorEventsListView = isMidiEditorEventsListView(hwnd);
-		if (focusIsMidiEditorEventsListView) {
+		if (isMidiEditorEventsListView(hwnd)) {
 			maybePreviewCurrentNoteInEventList(hwnd);
 		}
 		if (lastMessageHwnd && hwnd != lastMessageHwnd) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1766,6 +1766,11 @@ bool isListView(HWND hwnd) {
 	return isClassName(hwnd, "SysListView32");
 }
 
+bool isMidiEditorEventsListView(HWND hwnd) {
+	return isListView(hwnd)
+		&& isClassName(GetAncestor(hwnd, GA_PARENT), "REAPERmidieditorwnd");
+}
+
 HWND getPreferenceDescHwnd(HWND pref) {
 	// A preference control is always in a property page inside a dialog.
 	// There may be nested property pages.
@@ -3350,6 +3355,11 @@ void CALLBACK handleWinEvent(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG ob
 			// Give these objects a non-generic role so NVDA doesn't fall back to
 			// screen scraping, which causes spurious messages to be reported.
 			annotateAccRole(hwnd, ROLE_SYSTEM_PANE);
+		}
+
+		bool focusIsMidiEditorEventsListView = isMidiEditorEventsListView(hwnd);
+		if (focusIsMidiEditorEventsListView) {
+			maybePreviewCurrentNoteInEventList(hwnd);
 		}
 		if (lastMessageHwnd && hwnd != lastMessageHwnd) {
 			// Focus is moving. Clear our tweak to accName for the previous focus.


### PR DESCRIPTION
Fixes #410

@jcsteh I'm afraid this went a bit of a mix between C and C++. I considered using a std::string in place of the c style string, from C++17 and onwards it should be possible to provide string.data() as a pointer to functions that expect C style strings. However, there were some issues in reusing the string for the several calls I implemented.