### PR TITLE
Add feedback to actions in midi event list editor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -332,8 +332,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - View: Go to end of file: Control+End
 - Edit: Move edit cursor right one pixel: Alt+RightArrow or Control+Alt+Numpad6
 - Edit: Move edit cursor left one pixel: Alt+LeftArrow or Control+Alt+Numpad4
-- Edit: Move edit cursor right by grid: Alt+Shift+RightArrow or Control+Numpad6
-- Edit: Move edit cursor left by grid: Alt+Shift+LeftArrow or Control+Numpad4
+- Navigate: Move edit cursor right by grid: Alt+Shift+RightArrow or Control+Numpad6
+- Navigate: Move edit cursor left by grid: Alt+Shift+LeftArrow or Control+Numpad4
 - Navigate: Move edit cursor right one measure: PageDown
 - Navigate: Move edit cursor left one measure: PageUp
 - Edit: Increase pitch cursor one semitone: Alt+UpArrow or Ctrl+NumPad8

--- a/src/osara.h
+++ b/src/osara.h
@@ -240,8 +240,6 @@ bool isTrackSelected(MediaTrack* track);
 std::wstring widen(const std::string& text);
 std::string narrow(const std::wstring& text);
 bool isClassName(HWND hwnd, std::string className);
-bool isMidiEditorEventListView(HWND hwnd);
-void sendNameChangeEventToMidiEditorEventListItem(HWND hwnd);
 
 extern IAccPropServices* accPropServices;
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -240,6 +240,8 @@ bool isTrackSelected(MediaTrack* track);
 std::wstring widen(const std::string& text);
 std::string narrow(const std::wstring& text);
 bool isClassName(HWND hwnd, std::string className);
+bool isMidiEditorEventListView(HWND hwnd);
+void sendNameChangeEventToMidiEditorEventListItem(HWND hwnd);
 
 extern IAccPropServices* accPropServices;
 


### PR DESCRIPTION
This pr does the following:

1. Actions we support in the midi editor and that are also supported in the event list, are now all intercepted.
2. Actions that change a value in the event list fire a name change event. This should lead to the following behavior:

* With UIA: feedback as in the midi editor
* Without UIA: a name change event is sent to the focused item in the list, therefore speech should read the new name and braille should update appropriately

Note that with UIA, name change events are also sent, however the behaviour with regard to speaking them is a bit undetermined, probably because the name change is intercepted earlier than the UIA notification even though the UIA notification comes before the name change.

I also found several issues with regard to actions that change note position or note length. Though they seem to change values in the focused note, the value in the event list is not updated at all. For example,, changing note lengths in the midi event list should only be possible when doing something like this:

1. Select a note
2. Change the length with the shorten/lengthen notes by grid action
3. Press alt+1 to go back to the midi view
4. Press alt+3 to return to the events view

If you apply steps 1 and 2 twice (i.e. multiple notes), only the last note remains changed aafter switching back and forth to the event list.
I've seen this behavior with the change length actions, the change position (move left/right by grid) actions, and the join notes action. Velocity and pitch seem to work well, though REAPER's own note preview doesn't work in the event list.