### PR TITLE
Fix off by one error when getting note channel in midi event list for preview

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1015,7 +1015,7 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 	text[0] = '\0';
 	// Get the text from the channel column (3).
 	ListView_GetItemText(hwnd, focused, 3, text, sizeof(text));
-	note.channel = atoi(text);
+	note.channel = atoi(text) -1;
 	text[0] = '\0';
 	// Get the text from the parameter (note name) column (5).
 	ListView_GetItemText(hwnd, focused, 5, text, sizeof(text));


### PR DESCRIPTION
It looks like channels in Reaper are zero based.

Fixes #420 