### PR TITLE
Install correctly on Mac when Library/Application Support/REAPER doesn't exist yet

### DIFF
--- a/installer/mac/content/Install OSARA.command
+++ b/installer/mac/content/Install OSARA.command
@@ -37,7 +37,7 @@ function run(argv) {
 
 	var s = app.doShellScript;
 	try{
-		s(`mkdir '${target}/UserPlugins'`);
+		s(`mkdir -p '${target}/UserPlugins'`);
 	} catch (ignore){}// directory probably already exists
 	s(`cat '${source}/reaper_osara.dylib' > '${target}/UserPlugins/reaper_osara.dylib'`);
 	try{


### PR DESCRIPTION
Add -p to mkdir to create the directory if it doesn't exist.
Fixes #427.