### PR TITLE
Fix Mac OS Builds and update version/copyright year

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,15 @@
-version: "2020.1pre-{build}"
+version: "2021.1pre-{build}"
 
 branches:
  only:
   - master
+  - macOsTest
 
 environment:
  matrix:
   - job_name: Windows
     appveyor_build_worker_image: Visual Studio 2019
-    PY_PYTHON: 3.7-32
+    PY_PYTHON: 3.9-32
   - job_name: Mac
     appveyor_build_worker_image: macos
  global:
@@ -50,7 +51,7 @@ install:
  - git submodule update --init
 
 build_script:
- - ps: If ($IsWindows) { $scons = "c:\python37\scripts\scons.exe" } Else { $scons = "/Users/appveyor/Library/Python/3.7/bin/scons" }
+ - ps: If ($IsWindows) { $scons = "c:\python39\scripts\scons.exe" } Else { $scons = "/Users/appveyor/Library/Python/3.9/bin/scons" }
  - ps: '& $scons version=$env:APPVEYOR_BUILD_VERSION publisher="James Teh"'
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ version: "2021.1pre-{build}"
 branches:
  only:
   - master
-  - macOsTest
 
 environment:
  matrix:

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # OSARA: Open Source Accessibility for the REAPER Application
 
 - Author: James Teh &lt;jamie@jantrid.net&gt; & other contributors
-- Copyright: 2014-2020 NV Access Limited, James Teh & other contributors
+- Copyright: 2014-2021 NV Access Limited, James Teh & other contributors
 - License: GNU General Public License version 2.0
 
 OSARA is a [REAPER](http://www.reaper.fm/) extension which aims to make REAPER accessible to screen reader users.

--- a/sconstruct
+++ b/sconstruct
@@ -11,7 +11,7 @@ vars.Add("version", "The version of this build", "unknown")
 vars.Add("publisher", "The publisher of this build", "unknown")
 env = Environment(tools = ["default", "textfile"],
 	variables=vars,
-	copyright="Copyright (C) 2014-2020 NV Access Limited, James Teh & other contributors",
+	copyright="Copyright (C) 2014-2021 NV Access Limited, James Teh & other contributors",
 )
 
 if env["PLATFORM"] == "win32":


### PR DESCRIPTION
Looks like Python 3.9 is the way to go with scons