### PR TITLE
scons: Don't hard-code Xcode directory.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,7 @@ install:
       cd ..
      }
  - git submodule update --init
+ - sh: sudo xcode-select -s /Applications/Xcode-12.3.app
 
 build_script:
  - ps: If ($IsWindows) { $scons = "c:\python39\scripts\scons.exe" } Else { $scons = "/Users/appveyor/Library/Python/3.9/bin/scons" }

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -49,9 +49,13 @@ else: # Mac
 	swellDir = env.Dir("#include/WDL/WDL/swell")
 	env.Append(CPPPATH=(swellDir,))
 	env["CXX"] = "clang++"
+	import subprocess
+	env["xcodeDevDir"] = (
+		subprocess.check_output(("xcode-select", "-p"))
+		.decode().strip())
 	coreFlags = ("-mmacosx-version-min=10.7 -stdlib=libc++ "
 		"-arch x86_64 -arch arm64 "
-		"-isysroot /Applications/Xcode-12.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+		"-isysroot $xcodeDevDir/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
 	cxxFlags = coreFlags + " -std=c++17 -Werror"
 	env.Append(CXXFLAGS=cxxFlags)
 	env.Append(LINKFLAGS=coreFlags)


### PR DESCRIPTION
Instead, run xcode-select on AppVeyor. Users with multiple versions of Xcode installed will need to do the same, but this is probably rare.
Fixes #457.