### PR TITLE
Use keyWindow instead of mainWindow when posting Mac a11y announcements.

### DIFF
--- a/src/osxa11y.mm
+++ b/src/osxa11y.mm
@@ -35,6 +35,6 @@ namespace NSA11yWrapper {
   NSDictionary *announcementInfo = @{NSAccessibilityAnnouncementKey : message,
 				     NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh)};
 
-  NSAccessibilityPostNotificationWithUserInfo([NSApp mainWindow], NSAccessibilityAnnouncementRequestedNotification, announcementInfo);
+  NSAccessibilityPostNotificationWithUserInfo([NSApp keyWindow], NSAccessibilityAnnouncementRequestedNotification, announcementInfo);
 }
 @end


### PR DESCRIPTION
I'm hoping this might fix OSARA messages on mac when REAPER is full screen, but I really have no clue. It's just a hunch and a completely untested one at that.

@pitermach, @TimNoonanVoice, @kyleman, would you mind testing a build from here to see if it helps?

Fixes #149 (maybe).