### PR TITLE
Support for reporting track groups.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -667,6 +667,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Report global / Track Automation Mode: control+shift+l
 - OSARA: Toggle global automation override between latch preview and off: control+alt+shift+l
 - OSARA: Cycle through midi recording modes of selected tracks: alt+shift+\
+- OSARA: Report groups for current track
 - OSARA: About
 
 #### Midi editor

--- a/src/osara.h
+++ b/src/osara.h
@@ -184,6 +184,9 @@
 #define REAPERAPI_WANT_get_ini_file
 #define REAPERAPI_WANT_TrackFX_AddByName
 #define REAPERAPI_WANT_TrackFX_Delete
+#define REAPERAPI_WANT_GetSetTrackGroupMembership
+#define REAPERAPI_WANT_GetSetTrackGroupMembershipHigh
+#define REAPERAPI_WANT_GetSetProjectInfo_String
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
1. When navigating to a track, report if it is grouped.
2. Add OSARA: Report groups for current track action to report full group information.

Fixes #316.