### PR TITLE
Build Mac dmg with HFS+ file system so it can be mounted on Mac OS 10.11.

### DIFF
--- a/installer/mac/build.sh
+++ b/installer/mac/build.sh
@@ -18,5 +18,5 @@ cd ../..
 rm -f $dmg
 # We seem to need a delay here to avoid an "hdiutil: create failed - Resource busy" error.
 sleep 1
-hdiutil create -volname "OSARA $version" -srcfolder content $dmg
+hdiutil create -fs HFS+ -volname "OSARA $version" -srcfolder content $dmg
 rm -rf content/copying.txt content/.data


### PR DESCRIPTION
[Issue reported on RWP](https://groups.io/g/rwp/message/62719). This fix is untested, but I gleaned this fix from [this Stack Exchange thread](https://apple.stackexchange.com/questions/344414/create-dmg-file-on-macos-10-14-that-can-be-opened-on-macos-10-11).