### PR TITLE
Midi velocity feedback fixes

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1142,10 +1142,10 @@ void postMidiChangeVelocity(int command) {
 				s << "velocity +1";
 				break;
 			case 40463:
-				s << "velocity -1";
+				s << "velocity +10";
 				break;
 			case 40464:
-				s << "velocity +10";
+				s << "velocity -1";
 				break;
 			case 40465:
 				s << "velocity -10";


### PR DESCRIPTION
Action feedback for decreasing velocity by 1 and increasing by 10 was the wrong way round.