### PR TITLE
Mac installer: Fix detection of portable copies to handle app renames in REAPER 6.29.

### DIFF
--- a/installer/mac/content/Install OSARA.command
+++ b/installer/mac/content/Install OSARA.command
@@ -7,6 +7,8 @@ var finder = Application("Finder");
 
 function isPortableReaper ( dir ) {
 	return (
+		finder.exists(Path(dir + "/REAPER.app")) ||
+		finder.exists(Path(dir + "/REAPER-ARM.app")) ||
 		finder.exists(Path(dir + "/REAPER64.app")) ||
 		finder.exists(Path(dir + "REAPER32.app")) )
 }


### PR DESCRIPTION
Untested. @tbdalgaard, would you mind testing this when a build shows up here in a few minutes?

Fixes #529.