### PR TITLE
Make it possible to open the OSARA FX Parameters dialog for the selected effect in the FX chain dialog.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -431,7 +431,7 @@ This is useful for parameters which are tedious or impossible to access otherwis
 
 #### Track/Item Parameters
 To access the parameter list for a track or an item, select the track or item you wish to work with.
-Then, press alt+p (OSARA: View parameters for current track/item).
+Then, press alt+p (OSARA: View parameters for current track/item/FX (depending on focus)).
 
 #### FX Parameters
 Many effects are unfortunately either partially or completely inaccessible.
@@ -446,6 +446,9 @@ To access it:
 2. Alternatively, to access FX parameters for the master track, press shift+p (OSARA: View FX parameters for master track).
 3. If there is more than one effect on the track, select the desired effect from the menu.
  If there are input or monitoring FX on the track, these will be included in the menu as well with an appropriate suffix.
+
+You can also access the FX parameter list from the FX chain dialog.
+To do this, select the effect in the list and then press alt+p (OSARA: View parameters for current track/item/FX (depending on focus)).
 
 Note that only some effects expose easily readable values, while others expose only percentages.
 Even for effects that do expose easily readable values, the editable text is an internal number and probably won't correspond to the readable value on the slider.

--- a/src/fxChain.cpp
+++ b/src/fxChain.cpp
@@ -24,6 +24,11 @@
 
 using namespace std;
 
+bool isFxListFocused() {
+	return GetWindowLong(GetFocus(), GWL_ID) == 1076 &&
+		GetFocusedFX(nullptr, nullptr, nullptr) != 0;
+}
+
 #ifdef _WIN32
 
 bool maybeSwitchToFxPluginWindow() {
@@ -84,11 +89,6 @@ bool maybeSwitchToFxPluginWindow() {
 		window = GetParent(window);
 	}
 	return true;
-}
-
-bool isFxListFocused() {
-	return GetWindowLong(GetFocus(), GWL_ID) == 1076 &&
-		GetFocusedFX(nullptr, nullptr, nullptr) != 0;
 }
 
 // If the FX list in an FX chain dialog is focused, report active/bypassed for

--- a/src/fxChain.h
+++ b/src/fxChain.h
@@ -6,6 +6,7 @@
  * License: GNU General Public License version 2.0
  */
 
+bool isFxListFocused();
 bool maybeSwitchToFxPluginWindow();
 bool maybeReportFxChainBypass(bool aboutToToggle=false);
 bool maybeReportFxChainBypassDelayed();

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3646,7 +3646,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Move to next item (leaving other items selected)"}, "OSARA_NEXTITEMKEEPSEL", cmdMoveToNextItemKeepSel},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: Move to previous item (leaving other items selected)"}, "OSARA_PREVITEMKEEPSEL", cmdMoveToPrevItemKeepSel},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: View properties for current media item/take/automation item (depending on focus)"}, "OSARA_PROPERTIES", cmdPropertiesFocus},
-	{MAIN_SECTION, {DEFACCEL, "OSARA: View parameters for current track/item (depending on focus)"}, "OSARA_PARAMS", cmdParamsFocus},
+	{MAIN_SECTION, {DEFACCEL, "OSARA: View parameters for current track/item/FX (depending on focus)"}, "OSARA_PARAMS", cmdParamsFocus},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: View FX parameters for current track/take (depending on focus)"}, "OSARA_FXPARAMS", cmdFxParamsFocus},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: View FX parameters for master track"}, "OSARA_FXPARAMSMASTER", cmdFxParamsMaster},
 	{MAIN_SECTION, {DEFACCEL, "OSARA: View Peak Watcher"}, "OSARA_PEAKWATCHER", cmdPeakWatcher},


### PR DESCRIPTION
You do this by selecting the effect in the list and pressing alt+p (OSARA: View parameters for current track/item/FX).

I'm not sure if this is going to work on Mac. Assuming it builds, it will need testing.

Fixes #538.