### PR TITLE
When loading a translation, correctly handle the UTF-8 path returned from REAPER on Windows.

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -59,7 +59,15 @@ void initTranslation() {
 	string path(GetResourcePath());
 	path += "/osara/locale/";
 	path += name;
+#ifdef _WIN32
+	// REAPER provides UTF-8 strings. However, on Windows, ifstream will
+	// interpret a narrow (8 bit) string as an ANSI string. The easiest way to
+	// deal with this is to convert the string to UTF-16, which Windows will
+	// interpret correctly.
+	ifstream input(widen(path));
+#else
 	ifstream input(path);
+#endif
 	tinygettext::POParser::parse(path, input, translationDict);
 }
 


### PR DESCRIPTION
Previously, this was being passed to Windows as an ANSI string.
This meant that a translation couldn't load when the REAPER resource path contained non-ASCII characters.