### PR TITLE
Catch possible exception when trying to determine the note for MIDI event list preview.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1092,6 +1092,9 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 		try {
 			octave = stoi(noteNameWithOctave.substr(noteNameLength, 2));
 		} catch (invalid_argument) {
+			// If a REAPER language pack translates note names, we might get something
+			// unexpected here. There's nothing we can do to compensate, so just
+			// gracefully ignore this.
 			continue;
 		}
 		note.pitch = ((octave + 1) * 12) + i;

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1088,7 +1088,12 @@ void maybePreviewCurrentNoteInEventList(HWND hwnd) {
 		// Therefore, the number counts either one or two characters in noteNameWithOctave.
 		// If the note is explicitly named, the name comes after the octave and a space.
 		// As stoi simply ignores whitespace or the end of a string, all possible appearances should be covered.
-		int octave = stoi(noteNameWithOctave.substr(noteNameLength, 2));
+		int octave;
+		try {
+			octave = stoi(noteNameWithOctave.substr(noteNameLength, 2));
+		} catch (invalid_argument) {
+			continue;
+		}
 		note.pitch = ((octave + 1) * 12) + i;
 		break;
 	}


### PR DESCRIPTION
It seems that REAPER language packs can translate note names.
If a translated note name matches the start of an English note name (e.g. "Fa" will match "F"), stoi (used to get the octave) will then barf because "a" isn't a number.
For now, just catch this exception and gracefully ignore it to prevent a crash.
In future, we're going to have to figure out how to deal with translated note names.
Fixes #545.