### PR TITLE
Windows installer: Ask about key map replacement using a message box  instead of showing it as an optional component.

### DIFF
--- a/installer/osara.nsi
+++ b/installer/osara.nsi
@@ -1,7 +1,7 @@
 ; OSARA: Open Source Accessibility for the REAPER Application
 ; NSIS installer script
 ; Author: James Teh <jamie@jantrid.net>
-; Copyright 2016 NV Access Limited
+; Copyright 2016-2021 NV Access Limited, James Teh
 ; License: GNU General Public License version 2.0
 
 !include "MUI2.nsh"
@@ -29,7 +29,6 @@ RequestExecutionLevel user
 Page custom portablePage portablePageLeave
 !define MUI_PAGE_CUSTOMFUNCTION_PRE directoryPagePre
 !insertmacro MUI_PAGE_DIRECTORY
-!insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_INSTFILES
 
 !insertmacro MUI_UNPAGE_CONFIRM
@@ -103,9 +102,16 @@ Section "OSARA plug-in" SecPlugin
 SectionEnd
 
 Section "Replace existing key map with OSARA key map" SecKeyMap
+	MessageBox MB_YESNO|MB_ICONQUESTION \
+		"Do you want to replace the existing key map with the OSARA key map?$\r$\n\
+		New users are advised to answer Yes, which will completely replace your key map with a clean copy of the OSARA key map including all latest assignments.$\r$\n\
+		Answering No will install OSARA without modifying your key map, which may be preferable for experienced users who have prior alterations that they'd like to preserve." \
+		/SD IDNO IDNO dontReplaceKeyMap
+	; If we reach here, the user chose yes.
 	SetOutPath "$INSTDIR"
 	Rename "reaper-kb.ini" "KeyMaps\OSARAReplacedBackup.ReaperKeyMap"
 	File "..\config\windows\reaper-kb.ini"
+	dontReplaceKeyMap:
 SectionEnd
 
 Section "Uninstall"

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,7 @@ Once you have downloaded the installer, simply run it and follow the instruction
 Note that if you previously copied the OSARA extension into REAPER's program directory manually (before the installer became available), you must remove this first.
 The installer installs the extension into your user configuration, not the program directory.
 
-By default, the OSARA key map will be installed, completely replacing your existing key map.
-If you do not wish this to occur, you can uncheck the "Replace existing key map with OSARA key map" option.
+If you wish to completely replace your existing key map with the OSARA key map (which is recommended), answer yes when prompted.
 If the installer does replace the key map, a backup of your existing key map will be made in Reaper's KeyMaps folder.
 
 ### Mac


### PR DESCRIPTION
This makes it more obvious to users and should avoid accidental key map overwriting.
The answer defaults to no.
Fixes #579.