### PR TITLE
Add action to mute the next message from OSARA

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -694,6 +694,9 @@ OSARA also includes some other miscellaneous actions.
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f
 
+### Muting OSARA messages in custom/cycle actions
+The action "OSARA: Mute next message from OSARA" can be used in custom/cycle actions to mute OSARA feedback for the next action. It should be placed before each action to be muted.
+
 ## Support
 If you need help, please subscribe to the [Reapers Without Peepers discussion group](https://groups.io/g/rwp) and ask your questions there.
 

--- a/readme.md
+++ b/readme.md
@@ -694,8 +694,9 @@ OSARA also includes some other miscellaneous actions.
 #### MIDI Event List Editor
 - OSARA: Focus event nearest edit cursor: control+f
 
-### Muting OSARA messages in custom/cycle actions
-The action "OSARA: Mute next message from OSARA" can be used in custom/cycle actions to mute OSARA feedback for the next action. It should be placed before each action to be muted.
+### Muting OSARA Messages in Custom/Cycle Actions
+The action "OSARA: Mute next message from OSARA" can be used in custom/cycle actions to mute OSARA feedback for the next action.
+It should be placed before each action to be muted.
 
 ## Support
 If you need help, please subscribe to the [Reapers Without Peepers discussion group](https://groups.io/g/rwp) and ask your questions there.

--- a/src/osara.h
+++ b/src/osara.h
@@ -199,6 +199,7 @@ const char CONFIG_SECTION[] = "osara";
 
 const int MAIN_SECTION = 0;
 const int MIDI_EVENT_LIST_SECTION = 32061;
+const int MEDIA_EXPLORER_SECTION = 32063;
 
 // Needed for REAPER API functions which take a bool as an input pointer.
 static bool bFalse = false;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4026,7 +4026,7 @@ bool handleCommand(KbdSectionInfo* section, int command, int val, int valHw, int
 		return true;
 	} else if (handlePostCommand(section->uniqueID, command, val, valHw, relMode,
 			hwnd)) {
-				muteNextMessage = false;
+		muteNextMessage = false;
 		return true;
 	}
 	return false;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3802,9 +3802,12 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to previous midi item on track"}, "OSARA_MIDIPREVITEM", cmdMidiMoveToPrevItem},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Move to next midi item on track"}, "OSARA_MIDINEXTITEM", cmdMidiMoveToNextItem},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Select all notes with the same pitch starting in time selection"}, "OSARA_SELSAMEPITCHTIMESEL", cmdMidiSelectSamePitchStartingInTimeSelection},
+	{ MIDI_EDITOR_SECTION, {DEFACCEL, "OSARA: Mute next message from OSARA"}, "OSARA_MUTENEXTMESSAGE", cmdMuteNextMessage},
 #ifdef _WIN32
 	{MIDI_EVENT_LIST_SECTION, {DEFACCEL, "OSARA: Focus event nearest edit cursor"}, "OSARA_FOCUSMIDIEVENT", cmdFocusNearestMidiEvent},
 #endif
+	{ MIDI_EVENT_LIST_SECTION, {DEFACCEL, "OSARA: Mute next message from OSARA"}, "OSARA_MUTENEXTMESSAGE", cmdMuteNextMessage},
+	{ MEDIA_EXPLORER_SECTION, {DEFACCEL, "OSARA: Mute next message from OSARA"}, "OSARA_MUTENEXTMESSAGE", cmdMuteNextMessage},
 	// translate firstString end
 	{0, {}, NULL, NULL},
 };


### PR DESCRIPTION
For use in custom actions.  Suppresses OSARA output for the next command handled by OSARA.  See comments in issue #600.
Fixes #600.