### PR TITLE
Update appveyor builds to newest tooling

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 environment:
  matrix:
   - job_name: Windows
-    appveyor_build_worker_image: Visual Studio 2019
+    appveyor_build_worker_image: Visual Studio 2022
     PY_PYTHON: 3.9-32
   - job_name: Mac
     appveyor_build_worker_image: macos
@@ -50,7 +50,7 @@ install:
       cd ..
      }
  - git submodule update --init
- - sh: sudo xcode-select -s /Applications/Xcode-12.3.app
+ - sh: sudo xcode-select -s /Applications/Xcode-13.0.app
 
 build_script:
  - ps: If ($IsWindows) { $scons = "c:\python39\scripts\scons.exe" } Else { $scons = "/Users/appveyor/Library/Python/3.9/bin/scons" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
       cd ..
      }
  - git submodule update --init
- - sh: sudo xcode-select -s /Applications/Xcode-13.0.app
+ - sh: sudo xcode-select -s /Applications/Xcode-13.app
 
 build_script:
  - ps: If ($IsWindows) { $scons = "c:\python39\scripts\scons.exe" } Else { $scons = "/Users/appveyor/Library/Python/3.9/bin/scons" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     appveyor_build_worker_image: Visual Studio 2022
     PY_PYTHON: 3.9-32
   - job_name: Mac
-    appveyor_build_worker_image: macos
+    appveyor_build_worker_image: macos-bigsur
  global:
   encFileKey:
    secure: hN4Qfteiu6qqPajSvT+vrPfVoazOY+MFAlwUt/kZSnM=

--- a/readme.md
+++ b/readme.md
@@ -752,12 +752,13 @@ To build OSARA, you will need:
 
 - Several git submodules used by OSARA.
 	See the note about submodules in the previous section.
-- Windows only: Microsoft Visual Studio 2019 Community:
-	* [Download Visual Studio 2019 Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16)
+- Windows only: Build Tools for Microsoft Visual Studio 2022:
+	* [Download Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
+	* Visual Studio 2022 Community/Professional/Enterprise is also supported.
 	* When installing Visual Studio, you need to enable the following:
 		- On the Workloads tab, in the Windows group: Desktop development with C++
-- Mac only: Xcode 12.3:
-	* You can download Xcode 12.3 from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?ls=1&mt=12).
+- Mac only: Xcode 13:
+	* You can download Xcode 13 from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?ls=1&mt=12).
 - Python, version 3.7 or later:
 	* This is needed by SCons.
 	* [Download Python](https://www.python.org/downloads/)

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -33,7 +33,7 @@ sources = [
 ]
 
 if env["PLATFORM"] == "win32":
-	env.Append(CXXFLAGS="/EHsc /std:c++latest /W3 /WX "
+	env.Append(CXXFLAGS="/EHsc /std:c++20 /W3 /WX "
 		# #479: fmt/format.h includes UTF-8 characters in comments. However, cl
 		# treats the file as ANSI unless it has a BOM. This causes a warning (and
 		# thus an error) on systems with certain locales. Just disable this warning.
@@ -69,7 +69,7 @@ else: # Mac
 	coreFlags = ("-mmacosx-version-min=10.7 -stdlib=libc++ "
 		"-arch x86_64 -arch arm64 "
 		"-isysroot $xcodeDevDir/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
-	cxxFlags = coreFlags + " -std=c++17 -Werror"
+	cxxFlags = coreFlags + " -std=c++20 -Werror"
 	env.Append(CXXFLAGS=cxxFlags)
 	env.Append(LINKFLAGS=coreFlags)
 	env.Append(CPPDEFINES="SWELL_PROVIDED_BY_APP")


### PR DESCRIPTION
Updates to Visual Studio 2022 / XCode 13.0. The latter requires us to use the big sur image.
This finally allows us to pinpoint C++ support to C++20 for both environments. Very welcome because yesterday, I bumped into several case where code didn't compile on Mac. I'm not sure whether C++20 is fully covered though.