### PR TITLE
Ensure we don't ignore keys in the keyboard hook we shouldn't ignore

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2294,9 +2294,10 @@ bool maybeFixTabInSaveDialog(bool previous) {
 LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 	const bool isKeyDown = !(lParam & 0x80000000);
 	if (!isKeyDown || code != HC_ACTION || (
-		wParam != VK_APPS && wParam != VK_RETURN &&
+		wParam != VK_APPS && wParam != VK_CONTROL &&
+				wParam != VK_F10 && wParam != VK_RETURN &&
 				wParam != VK_F6 && wParam != 'B' &&
-				wParam != VK_TAB && wParam != VK_CONTROL)) {
+				wParam != VK_TAB && wParam != VK_DOWN)) {
 		// Return early if we're not interested in the key.
 		return CallNextHookEx(NULL, code, wParam, lParam);
 	}


### PR DESCRIPTION
Fixes #606

When refactoring the keyboard hook in #598 , there was one thing I forgot about, namely checking whether the initial if clause that ignored keys we weren't interested in was complete. That wasn't the case, therefore shift+f10 and alt+downArrow didn't work. It should be fixed with this pr.

The keys are now listed in the order in they are used later on in the code 