### PR TITLE
Shorten FX names reported when navigating tracks

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -768,7 +768,22 @@ void postGoToTrack(int command, MediaTrack* track) {
 			if (f > 0)
 				s << ", ";
 			TrackFX_GetFXName(track, f, name, sizeof(name));
-			s << name;
+			const regex RE_FX_NAME("^([A-Z]+): (.+?)( \\(.*?\\))?$");
+			cmatch m;
+			regex_search(name, m, RE_FX_NAME);
+			if (m.empty()) {
+				s << name;
+			} else {
+				// Group 1 is the prefix, group 2 is the FX name, group 3 is the
+				// parenthesised suffix.
+				s << m.str(2);
+				if (m.str(1) == "JS") {
+					// For JS, not all effects have a vendor name. Therefore, we always
+					// include the parenthesised suffix to avoid stripping potentially
+					// useful info.
+					s << m.str(3);
+				}
+			}
 			if (!TrackFX_GetEnabled(track, f)) {
 				s << " " << translate("bypassed");
 			}


### PR DESCRIPTION
Strip the type prefix (VST, JS, etc.) and strip the vendor suffix in parentheses.
One problem with this is that not all JS effects have a vendor suffix, but some use a parenthesised suffix for other reasons; e.g.
JS: Transient-Driven Auto-Pan (Transmitter)
With this PR, we strip (Transmitter) from that last one, and given that there's an accompanying (Receiver) plugin, that is not ideal.
Still, this is a rare edge case, and it may be worth sacrificing it for the overall benefit this brings.
Fixes #608.