### PR TITLE
Parameters dialog: Don't close the dialog on Mac if something steals focus.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -435,6 +435,7 @@ class ParamsDialog {
 				DestroyWindow(dialogHwnd);
 				delete dialog;
 				return TRUE;
+#ifdef _WIN32
 			case WM_ACTIVATE:
 				if (!dialog->isDestroying && LOWORD(wParam) == WA_INACTIVE) {
 					// If something steals focus, close the dialog. Otherwise, we won't
@@ -446,6 +447,7 @@ class ParamsDialog {
 					PostMessage(dialogHwnd, WM_CLOSE, 0, 0);
 					return TRUE;
 				}
+#endif
 		}
 		return FALSE;
 	}


### PR DESCRIPTION
This is an experiment to see if this makes #633 go away. This isn't an acceptable fix long-term, but it might help in reporting the right thing to Cockos.
@tbdalgaard, @ScottChesworth, can you give this a shot?