### PR TITLE
Build OSARA with LLVM (Clang/LLD) on Windows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -756,8 +756,10 @@ To build OSARA, you will need:
 	* [Download Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
 	* Visual Studio 2022 Community/Professional/Enterprise is also supported.
 	* Whether installing Build Tools or Visual Studio, you must enable the following:
-		- On the Workloads tab, in the Windows group: Desktop development with C++
-		- On the Workloads tab, in the Optional group: C++ ATL for latest v143 build tools (x86 & x64)
+		- In the list on the Workloads tab, in the Windows grouping: Desktop development with C++
+		- Then in the Installation details tree view, under Desktop development with C++ > Optional:
+			* C++ ATL for latest v143 build tools (x86 & x64)
+			* C++ Clang tools for Windows
 - Mac only: Xcode 13:
 	* You can download Xcode 13 from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?ls=1&mt=12).
 - Python, version 3.7 or later:

--- a/sconstruct
+++ b/sconstruct
@@ -23,7 +23,7 @@ print("Building using {} jobs".format(env.GetOption('num_jobs')))
 if env["PLATFORM"] == "win32":
 	for arch, suffix in (("x86", "32"), ("x86_64", "64")):
 		archEnv = Environment(tools = ["default", "textfile"],
-			TARGET_ARCH=arch, libSuffix=suffix,
+			TARGET_ARCH=arch, HOST_ARCH=arch, libSuffix=suffix,
 			version=env["version"], copyright=env["copyright"],
 			# Hack around an odd bug where some tool after msvc states that static and shared objects are different.
 			STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME=1)

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -33,11 +33,26 @@ sources = [
 ]
 
 if env["PLATFORM"] == "win32":
-	env.Append(CXXFLAGS="/EHsc /std:c++20 /W3 /WX "
-		# #479: fmt/format.h includes UTF-8 characters in comments. However, cl
-		# treats the file as ANSI unless it has a BOM. This causes a warning (and
-		# thus an error) on systems with certain locales. Just disable this warning.
-		"/wd4819")
+	# On Windows, OSARA is build with LLVM to have a toolchain that's closer to what's used on Mac
+	env["CC"] = "clang-cl"
+	env["LINK"] = "lld-link"
+	env.Append(CCFLAGS=[
+		"/W3",
+		"/WX",
+		# Clang warns about unused functions in WDL
+		"/clang:-Wno-unused-function",
+	])
+	env.Append(CXXFLAGS=[
+		"/clang:-std=c++20",
+		"/EHsc",
+		# Ignore suggestions to add braces around initialization of subobjects. We might want to fix this at some point
+		"/clang:-Wno-missing-braces",
+	])
+	env.Append(CFLAGS=[
+		# Ignore warnings in WDL/win32_utf8.c, not our code
+		"/clang:-Wno-deprecated-declarations",
+		"/clang:-Wno-unused-variable"
+	])
 	# We always want debug symbols.
 	env.Append(PDB="${TARGET}.pdb")
 	# having symbols usually turns this off, but we have no need for unused symbols.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1037,7 +1037,7 @@ void midiMoveToItem(int direction) {
 	MediaItem* item = GetMediaItemTake_Item(take);
 	MediaTrack* track = GetMediaItem_Track(item);
 	int count = CountTrackMediaItems(track);
-	int itemNum;
+	int itemNum = 1;
 	for (int i=0; i<count; ++i) {
 		MediaItem* itemTmp = GetTrackMediaItem(track, i);
 		if (itemTmp == item) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4180,7 +4180,7 @@ void CALLBACK handleWinEvent(HWINEVENTHOOK hook, DWORD event, HWND hwnd, LONG ob
 			}
 		}
 		HWND tempWindow;
-		if (tempWindow = getSendContainer(hwnd)) {
+		if ((tempWindow = getSendContainer(hwnd))) {
 			// #24: This is a button for a send in the Track I/O window.
 			// Tweak the name so the user knows what send it's for.
 			// Unfortunately, we can't annotate the accessible for the container.


### PR DESCRIPTION
This starts building OSARA with LLVM. This should at least bring C++20 coverage on Windows closer to that on Mac, though still not fully as pointed out in https://github.com/jcsteh/osara/pull/636#issuecomment-1008027322