### PR TITLE
When moving to a note in the MIDI Editor, report its velocity after its length if View -> Piano roll notes -> Show velocity numbers on notes is enabled.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -741,6 +741,10 @@ void moveToNoteInChord(int direction, bool clearSelection=true, bool select=true
 	}
 	if (shouldReportNotes) {
 		s << formatNoteLength(note.start, note.end);
+		if (GetToggleCommandState2(SectionFromUniqueID(MIDI_EDITOR_SECTION), 40632)
+				) { // View: Show velocity numbers on notes
+			s << ", " << note.velocity << " " << translate("velocity");
+		}
 	}
 	outputMessage(s);
 }


### PR DESCRIPTION
Fixes #626.
@ScottChesworth, @MatejGolian, I'd like some feedback here as to whether just reporting the value after a comma is intuitive enough:
d sharp 4, 25%, 96
The alternative would be to scrap the comma and report "velocity" instead:
d sharp 4, 25% velocity 96
Or we could keep the comma, and/or we could shorten velocity to "vel".
Thoughts? Trying to balance efficiency with intuitiveness here.