### PR TITLE
Do not assume the default path for the PHP interpreter, poll for it

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -98,8 +98,10 @@ else: # Mac
 	env["SHLIBPREFIX"] = ""
 
 	# Generate Mac resources.
+	import shutil
+	php = shutil.which("php")
 	res = env.Command(["reaper_osara.rc_mac_dlg", "reaper_osara.rc_mac_menu"], "reaper_osara.rc",
-		[["include/WDL/WDL/swell/swell_resgen.php", "$SOURCE"]])
+		[[php, "include/WDL/WDL/swell/swell_resgen.php", "$SOURCE"]])
 	env.Depends("reaper_osara.cpp", res)
 
 def addExternalSources(dir, files):


### PR DESCRIPTION
Do not assume the default path for the PHP interpreter but poll for it. Starting with Mac OS 12.x users will have to install 'PHP', e.g. using Homebrew, in order to compile OSARA.