### PR TITLE
Add feedback for removing or copying selected area of items. fixes #488

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -300,10 +300,15 @@ FX: Toggle delta solo for last focused FX
 #### Clipboard
 - Edit: Cut items/tracks/envelope points (depending on focus) ignoring time selection: Control+X
 - Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut): Control+Shift+X
+- Item: Copy selected area of items
+- Item: Copy loop of selected area of audio items
+- Edit: Cut items
 - Item: Cut selected area of items: Control+Win+X
 - Edit: Copy items/tracks/envelope points (depending on focus) ignoring time selection: Control+C
 - Edit: Copy items/tracks/envelope points (depending on focus) within time selection, if any (smart copy): Control+Shift+C
+- Track: Cut tracks
 - Item: Paste items/tracks: Control+V
+- Envelope: Cut points within time selection
 - Select all items/tracks/envelope points (depending on focus): control+a
 
 #### View

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Item: Set cursor to previous take marker in selected items
 - Item: Delete take marker at cursor
 - Item: Delete all take markers
+- Item: Remove selected area of items: Control+Win+Delete
 
 #### Takes
 - Take: Switch items to next take: T
@@ -299,6 +300,7 @@ FX: Toggle delta solo for last focused FX
 #### Clipboard
 - Edit: Cut items/tracks/envelope points (depending on focus) ignoring time selection: Control+X
 - Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut): Control+Shift+X
+- Item: Cut selected area of items: Control+Win+X
 - Edit: Copy items/tracks/envelope points (depending on focus) ignoring time selection: Control+C
 - Edit: Copy items/tracks/envelope points (depending on focus) within time selection, if any (smart copy): Control+Shift+C
 - Item: Paste items/tracks: Control+V

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2758,7 +2758,7 @@ void cmdRemoveTracks(Command* command) {
 	cmdhRemoveTracks(command->gaccel.accel.cmd);
 }
 
-void cmdRemoveAreaOfItems(Command* command) {
+void cmdRemoveOrCopyAreaOfItems(Command* command) {
 	double start, end;
 	GetSet_LoopTimeRange(false, true, &start, &end, false);
 	int selItems = CountSelectedMediaItems(nullptr);
@@ -2777,14 +2777,23 @@ void cmdRemoveAreaOfItems(Command* command) {
 				(itemStart < start && start < itemEnd) ||
 				(itemStart < end && end < itemEnd) ||
 				(start == itemStart && end == itemEnd)) {
-					++count;
-				}
+				++count;
+			}
 		}
-		// Translators: used for  "Item: Cut selected area of items" and "Item:
-		// Remove selected area of items".  {} is replaced by the number of items
-		// effected.
-		outputMessage(format(
-			translate_plural("selected area of {} item removed", "Selected area of {} items removed", count), count));
+		switch (command->gaccel.accel.cmd) {
+			case 40060: // Item: Copy selected area of items
+				// Translators: used for  "Item: Copy selected area of items".
+				// {} is replaced by the number of items effected.
+				outputMessage(format(
+					translate_plural("selected area of {} item copied", "Selected area of {} items copied", count), count));
+				break;
+			default: 
+				// Translators: used for  "Item: Cut selected area of items" and "Item:
+				// Remove selected area of items".  {} is replaced by the number of items
+				// effected.
+				outputMessage(format(
+					translate_plural("selected area of {} item removed", "Selected area of {} items removed", count), count));
+		}
 	}
 	Main_OnCommand(command->gaccel.accel.cmd, 0);
 }
@@ -3759,8 +3768,10 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40325}, NULL}, NULL, cmdDeleteEnvelopePoints}, // Envelope: Cut points within time selection
 	{MAIN_SECTION, {{0, 0, 40059}, NULL}, NULL, cmdCut}, // Edit: Cut items/tracks/envelope points (depending on focus) ignoring time selection
 	{MAIN_SECTION, {{0, 0, 40201}, NULL}, NULL, cmdRemoveTimeSelection}, // Time selection: Remove contents of time selection (moving later items)
-	{MAIN_SECTION, {{0, 0, 40312}, NULL}, NULL, cmdRemoveAreaOfItems}, // Item: Remove selected area of items
-	{MAIN_SECTION, {{0, 0, 40307}, NULL}, NULL, cmdRemoveAreaOfItems}, // Item: Cut selected area of items
+	{MAIN_SECTION, {{0, 0, 40312}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Remove selected area of items
+	{MAIN_SECTION, {{0, 0, 40307}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Cut selected area of items
+	{MAIN_SECTION, {{0, 0, 40060}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Copy selected area of items
+	{MAIN_SECTION, {{0, 0, 40014}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Copy loop of selected area of audio items
 	{MAIN_SECTION, {{0, 0, 40119}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points right
 	{MAIN_SECTION, {{0, 0, 40120}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points left
 	{MAIN_SECTION, {{0, 0, 40225}, NULL}, NULL, cmdMoveItemEdge}, // Item edit: Grow left edge of items

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2762,7 +2762,7 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 	double start, end;
 	GetSet_LoopTimeRange(false, true, &start, &end, false);
 	int selItems = CountSelectedMediaItems(nullptr);
-	auto countEffected = [start, end](MediaItem* (*getFunc)(ReaProject*, int), int totalCount) {
+	auto countAffected = [start, end](auto getFunc, int totalCount) {
 		int count = 0;
 		for(int i = 0; i < totalCount; ++i) {
 			MediaItem* item = getFunc(nullptr, i);
@@ -2772,41 +2772,42 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 				(start < itemEnd && itemEnd < end) ||
 				(itemStart < start && start < itemEnd) ||
 				(itemStart < end && end < itemEnd) ||
-				(start == itemStart && end == itemEnd)) {
+				(start == itemStart && end == itemEnd)
+			) {
 				++count;
 			}
 		}
 		return count;
 	};
 	if(start == end) {
-		outputMessage(translate("No time selection"));
+		outputMessage(translate("no time selection"));
 	} else {
 		switch (command->gaccel.accel.cmd) {
 			case 40060: // Item: Copy selected area of items
 			case 40014: { // Item: Copy loop of selected area of audio items
 				if(selItems == 0) {
-					outputMessage(translate("No items selected"));
+					outputMessage(translate("no items selected"));
 					break;
 				}
-				int count = countEffected(GetSelectedMediaItem, selItems);
+				int count = countAffected(GetSelectedMediaItem, selItems);
 				// Translators: used for  "Item: Copy selected area of items".
-				// {} is replaced by the number of items effected.
+				// {} is replaced by the number of items affected.
 				outputMessage(format(
-					translate_plural("selected area of {} item copied", "Selected area of {} items copied", count), count));
+					translate_plural("selected area of {} item copied", "selected area of {} items copied", count), count));
 				break;
 			}
 			default: {
 				int count = 0;
 				if(selItems == 0) { // these commands treat no item selection as if all items are selected
-					count = countEffected(GetMediaItem, CountMediaItems(nullptr));
+					count = countAffected(GetMediaItem, CountMediaItems(nullptr));
 				} else {
-					count = countEffected(GetSelectedMediaItem, selItems);
+					count = countAffected(GetSelectedMediaItem, selItems);
 				}
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
-				// effected.
+				// affected.
 				outputMessage(format(
-					translate_plural("selected area of {} item removed", "Selected area of {} items removed", count), count));
+					translate_plural("selected area of {} item removed", "selected area of {} items removed", count), count));
 			}
 		}
 	}

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2775,7 +2775,8 @@ void cmdRemoveAreaOfItems(Command* command) {
 			if((start < itemStart && itemStart < end) ||
 				(start < itemEnd && itemEnd < end) ||
 				(itemStart < start && start < itemEnd) ||
-				(itemStart < end && end < itemEnd)) {
+				(itemStart < end && end < itemEnd) ||
+				(start == itemStart && end == itemEnd)) {
 					++count;
 				}
 		}

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2758,7 +2758,7 @@ void cmdRemoveTracks(Command* command) {
 	cmdhRemoveTracks(command->gaccel.accel.cmd);
 }
 
-void cmdHRemoveAreaOfItems(int command) {
+void cmdRemoveAreaOfItems(Command* command) {
 	double start, end;
 	GetSet_LoopTimeRange(false, true, &start, &end, false);
 	int selItems = CountSelectedMediaItems(nullptr);
@@ -2785,11 +2785,7 @@ void cmdHRemoveAreaOfItems(int command) {
 		outputMessage(format(
 			translate_plural("selected area of {} item removed", "Selected area of {} items removed", count), count));
 	}
-	Main_OnCommand(command, 0);
-}
-
-void cmdRemoveAreaOfItems(Command* command) {
-	cmdHRemoveAreaOfItems(command->gaccel.accel.cmd);
+	Main_OnCommand(command->gaccel.accel.cmd, 0);
 }
 
 void cmdhRemoveItems(int command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2758,6 +2758,40 @@ void cmdRemoveTracks(Command* command) {
 	cmdhRemoveTracks(command->gaccel.accel.cmd);
 }
 
+void cmdHRemoveAreaOfItems(int command) {
+	double start, end;
+	GetSet_LoopTimeRange(false, true, &start, &end, false);
+	int selItems = CountSelectedMediaItems(nullptr);
+	if(start == end) {
+		outputMessage(translate("No time selection"));
+	} else if(!selItems) {
+		outputMessage(translate("No items selected"));
+	} else {
+		int count = 0;
+		for(int i = 0; i < selItems; ++i) {
+			MediaItem* item = GetSelectedMediaItem(nullptr, i);
+			double itemStart = GetMediaItemInfo_Value(item, "D_POSITION");
+			double itemEnd = GetMediaItemInfo_Value(item, "D_LENGTH");
+			if((start < itemStart && itemStart < end) ||
+				(start < itemEnd && itemEnd < end) ||
+				(itemStart < start && start < itemEnd) ||
+				(itemStart < end && end < itemEnd)) {
+					++count;
+				}
+		}
+		// Translators: used for  "Item: Cut selected area of items" and "Item:
+		// Remove selected area of items".  {} is replaced by the number of items
+		// effected.
+		outputMessage(format(
+			translate_plural("selected area of {} item removed", "Selected area of {} items removed", count), count));
+	}
+	Main_OnCommand(command, 0);
+}
+
+void cmdRemoveAreaOfItems(Command* command) {
+	cmdHRemoveAreaOfItems(command->gaccel.accel.cmd);
+}
+
 void cmdhRemoveItems(int command) {
 	int oldCount = CountMediaItems(0);
 	Main_OnCommand(command, 0);
@@ -3719,12 +3753,17 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40058}, NULL}, NULL, cmdPaste}, // Item: Paste items/tracks (old-style handling of hidden tracks)
 	{MAIN_SECTION, {{0, 0, 42398}, NULL}, NULL, cmdPaste}, // Item: Paste items/tracks
 	{MAIN_SECTION, {{0, 0, 40005}, NULL}, NULL, cmdRemoveTracks}, // Track: Remove tracks
+	{MAIN_SECTION, {{0, 0, 40337}, NULL}, NULL, cmdRemoveTracks}, // Track: Cut tracks
 	{MAIN_SECTION, {{0, 0, 40006}, NULL}, NULL, cmdRemoveItems}, // Item: Remove items
+	{MAIN_SECTION, {{0, 0, 40699}, NULL}, NULL, cmdRemoveItems}, // Edit: Cut items
 	{MAIN_SECTION, {{0, 0, 40333}, NULL}, NULL, cmdDeleteEnvelopePoints}, // Envelope: Delete all selected points
 	{MAIN_SECTION, {{0, 0, 40089}, NULL}, NULL, cmdDeleteEnvelopePoints}, // Envelope: Delete all points in time selection
+	{MAIN_SECTION, {{0, 0, 40336}, NULL}, NULL, cmdDeleteEnvelopePoints}, // Envelope: Cut selected points
+	{MAIN_SECTION, {{0, 0, 40325}, NULL}, NULL, cmdDeleteEnvelopePoints}, // Envelope: Cut points within time selection
 	{MAIN_SECTION, {{0, 0, 40059}, NULL}, NULL, cmdCut}, // Edit: Cut items/tracks/envelope points (depending on focus) ignoring time selection
-	{MAIN_SECTION, {{0, 0, 41384}, NULL}, NULL, cmdCut}, // Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut)
 	{MAIN_SECTION, {{0, 0, 40201}, NULL}, NULL, cmdRemoveTimeSelection}, // Time selection: Remove contents of time selection (moving later items)
+	{MAIN_SECTION, {{0, 0, 40312}, NULL}, NULL, cmdRemoveAreaOfItems}, // Item: Remove selected area of items
+	{MAIN_SECTION, {{0, 0, 40307}, NULL}, NULL, cmdRemoveAreaOfItems}, // Item: Cut selected area of items
 	{MAIN_SECTION, {{0, 0, 40119}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points right
 	{MAIN_SECTION, {{0, 0, 40120}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points left
 	{MAIN_SECTION, {{0, 0, 40225}, NULL}, NULL, cmdMoveItemEdge}, // Item edit: Grow left edge of items

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2771,7 +2771,7 @@ void cmdHRemoveAreaOfItems(int command) {
 		for(int i = 0; i < selItems; ++i) {
 			MediaItem* item = GetSelectedMediaItem(nullptr, i);
 			double itemStart = GetMediaItemInfo_Value(item, "D_POSITION");
-			double itemEnd = GetMediaItemInfo_Value(item, "D_LENGTH");
+			double itemEnd = itemStart + GetMediaItemInfo_Value(item, "D_LENGTH");
 			if((start < itemStart && itemStart < end) ||
 				(start < itemEnd && itemEnd < end) ||
 				(itemStart < start && start < itemEnd) ||

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2782,6 +2782,7 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 		}
 		switch (command->gaccel.accel.cmd) {
 			case 40060: // Item: Copy selected area of items
+			case 40014: // Item: Copy loop of selected area of audio items
 				// Translators: used for  "Item: Copy selected area of items".
 				// {} is replaced by the number of items effected.
 				outputMessage(format(


### PR DESCRIPTION
Add feedback for commands:
- Item: Remove selected area of items
- Item: Cut selected area of items
- Item: Copy loop of selected area of audio items
- Item: Copy selected area of items

Also provides useful feedback for:
- Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut)

fixes #488. Fixes #423.