### PR TITLE
Fix crash in Midi Event list caused by oversight in #659

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1538,7 +1538,7 @@ void maybeHandleEventListItemFocus(HWND hwnd, long childId) {
 		return;
 	}
 	// Check whether this is a note
-	if (event.length == 0) {
+	if (event.length == -1) {
 		// No Note
 		return;
 	}


### PR DESCRIPTION
In pull request #659, the MidiEventListData struct was changed to initialize several members to -1 by default, including the length member. However, to check whether a MidiEventListData is a note, we checked for `length == 0` before and that wasn't changed to reflect the new behaviour of default initialization to -1. This is now fixed.