### PR TITLE
Improve feedback for item movement commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Item: Remove items
 - Item edit: Move items/envelope points right: . or NumPad6
 - Item edit: Move items/envelope points left: , or NumPad4
+- Item edit: Move items/envelope points left by grid size: Alt+Shift+, or Control+Alt+NumPad4
+- Item edit: Move items/envelope points right by grid size: Alt+Shift+. or Control+Alt+NumPad6
 - Item edit: Grow left edge of items: Control+, or Control+NumPad4
 - Item edit: Shrink left edge of items: Control+. or Control+NumPad6
 - Item edit: Shrink right edge of items: Alt+, or Alt+NumPad4

--- a/readme.md
+++ b/readme.md
@@ -141,8 +141,8 @@ Most of these are actions built into REAPER, but a few are very useful actions f
 - Item: Remove items
 - Item edit: Move items/envelope points right: . or NumPad6
 - Item edit: Move items/envelope points left: , or NumPad4
-- Item edit: Move items/envelope points left by grid size: Alt+Shift+, or Control+Alt+NumPad4
 - Item edit: Move items/envelope points right by grid size: Alt+Shift+. or Control+Alt+NumPad6
+- Item edit: Move items/envelope points left by grid size: Alt+Shift+, or Control+Alt+NumPad4
 - Item edit: Grow left edge of items: Control+, or Control+NumPad4
 - Item edit: Shrink left edge of items: Control+. or Control+NumPad6
 - Item edit: Shrink right edge of items: Alt+, or Alt+NumPad4

--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -657,3 +657,40 @@ void postSelectMultipleEnvelopePoints(int command) {
 		translate_plural("{} point selected", "{} points selected", count),
 		count));
 }
+
+void cmdMoveSelEnvelopePoints(Command* command) {
+	TrackEnvelope* envelope;
+	double offset{0.0};
+	tie(envelope, offset) = getSelectedEnvelopeAndOffset();
+	if(!envelope || !currentEnvelopePoint || !shouldReportTimeMovement()) {
+		Main_OnCommand(command->gaccel.accel.cmd, 0);
+		return;
+	}
+	double oldPos {0.0};
+	GetEnvelopePointEx(envelope, currentAutomationItem, *currentEnvelopePoint, &oldPos, nullptr, nullptr, nullptr, nullptr);
+	oldPos += offset;
+	Main_OnCommand(command->gaccel.accel.cmd, 0);
+	double newPos{0.0};
+	GetEnvelopePointEx(envelope, currentAutomationItem, *currentEnvelopePoint, &newPos, nullptr, nullptr, nullptr, nullptr);
+	newPos += offset;
+	ostringstream s;
+	if(lastCommand != command->gaccel.accel.cmd) { 
+		const char* name = kbd_getTextFromCmd(command->gaccel.accel.cmd, nullptr);
+		const char* start;
+		// Skip the category before the colon (if any).
+		for (start = name; *start; ++start) {
+			if (*start == ':') {
+				name = start + 2;
+				break;
+			}
+		}
+		s<<name << " ";
+		resetTimeCache();
+	}
+	if(oldPos == newPos) {
+		s << translate("no change");
+	} else {
+		s << formatTime(newPos, TF_RULER, false, true);
+	}
+	outputMessage(s);
+}

--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -660,7 +660,7 @@ void postSelectMultipleEnvelopePoints(int command) {
 
 void cmdMoveSelEnvelopePoints(Command* command) {
 	TrackEnvelope* envelope;
-	double offset{0.0};
+	double offset;
 	tie(envelope, offset) = getSelectedEnvelopeAndOffset();
 	if(!envelope || !currentEnvelopePoint || !shouldReportTimeMovement()) {
 		Main_OnCommand(command->gaccel.accel.cmd, 0);
@@ -675,16 +675,7 @@ void cmdMoveSelEnvelopePoints(Command* command) {
 	newPos += offset;
 	ostringstream s;
 	if(lastCommand != command->gaccel.accel.cmd) { 
-		const char* name = kbd_getTextFromCmd(command->gaccel.accel.cmd, nullptr);
-		const char* start;
-		// Skip the category before the colon (if any).
-		for (start = name; *start; ++start) {
-			if (*start == ':') {
-				name = start + 2;
-				break;
-			}
-		}
-		s<<name << " ";
+		s << getActionName(command->gaccel.accel.cmd) << " ";
 		resetTimeCache();
 	}
 	if(oldPos == newPos) {

--- a/src/envelopeCommands.h
+++ b/src/envelopeCommands.h
@@ -32,3 +32,4 @@ void postToggleTrackVolumeEnvelope(int command);
 void postToggleTrackPanEnvelope(int command);
 void cmdToggleTrackEnvelope(Command* command);
 void postSelectMultipleEnvelopePoints(int command);
+void cmdMoveSelEnvelopePoints(Command* command);

--- a/src/osara.h
+++ b/src/osara.h
@@ -261,6 +261,7 @@ std::string formatTime(double time, TimeFormat format=TF_RULER, bool isLength=fa
 void resetTimeCache(TimeFormat excludeFormat=TF_NONE);
 std::string formatNoteLength(double start, double end);
 std::string formatCursorPosition(TimeFormat format=TF_RULER, bool useCache=true);
+const char* getActionName(int command, KbdSectionInfo* section=nullptr, bool skipCategory=true);
 
 bool isTrackSelected(MediaTrack* track);
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -241,7 +241,9 @@ extern enum FakeFocus fakeFocus;
 
 extern bool isSelectionContiguous;
 extern bool shouldMoveToAutoItem;
+extern int lastCommand;
 
+bool shouldReportTimeMovement() ;
 void outputMessage(const std::string& message, bool interrupt = true);
 void outputMessage(std::ostringstream& message, bool interrupt = true);
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2927,23 +2927,6 @@ void cmdRemoveTimeSelection(Command* command) {
 	}
 }
 
-void cmdMoveItems(Command* command) {
-	MediaItem* item = GetSelectedMediaItem(0, 0);
-	double oldPos, oldLen;
-	if (item) {
-		oldPos = *(double*)GetSetMediaItemInfo(item, "D_POSITION", NULL);
-		oldLen = *(double*)GetSetMediaItemInfo(item, "D_LENGTH", NULL);
-	}
-	Main_OnCommand(command->gaccel.accel.cmd, 0);
-	if (!item)
-		return;
-	// Only report if something actually happened.
-	double newPos = *(double*)GetSetMediaItemInfo(item, "D_POSITION", NULL);
-	double newLen = *(double*)GetSetMediaItemInfo(item, "D_LENGTH", NULL);
-	if (newPos != oldPos || newLen != oldLen)
-		reportActionName(command->gaccel.accel.cmd);
-}
-
 void cmdMoveItemEdge(Command* command) {
 	MediaItem* item = getItemWithFocus();
 	if (!item) {
@@ -2983,6 +2966,14 @@ void cmdMoveItemEdge(Command* command) {
 		s << translate("no change");
 	}
 	outputMessage(s);
+}
+
+void cmdMoveItemsOrEnvPoint(Command* command) {
+	if(GetCursorContext2(true) == 2 ) {// Envelope
+	cmdMoveSelEnvelopePoints(command);
+	} else {
+		cmdMoveItemEdge(command);
+	}
 }
 
 void cmdDeleteMarker(Command* command) {
@@ -3928,8 +3919,10 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40307}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Cut selected area of items
 	{MAIN_SECTION, {{0, 0, 40060}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Copy selected area of items
 	{MAIN_SECTION, {{0, 0, 40014}, NULL}, NULL, cmdRemoveOrCopyAreaOfItems}, // Item: Copy loop of selected area of audio items
-	{MAIN_SECTION, {{0, 0, 40119}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points right
-	{MAIN_SECTION, {{0, 0, 40120}, NULL}, NULL, cmdMoveItems}, // Item edit: Move items/envelope points left
+	{MAIN_SECTION, {{0, 0, 40119}, NULL}, NULL, cmdMoveItemsOrEnvPoint}, // Item edit: Move items/envelope points right
+	{MAIN_SECTION, {{0, 0, 40120}, NULL}, NULL, cmdMoveItemsOrEnvPoint}, // Item edit: Move items/envelope points left
+	{MAIN_SECTION, {{0, 0, 40793}, NULL}, NULL, cmdMoveItemsOrEnvPoint}, // Item edit: Move items/envelope points left by grid size
+	{MAIN_SECTION, {{0, 0, 40794}, NULL}, NULL, cmdMoveItemsOrEnvPoint}, // Item edit: Move items/envelope points right by grid size
 	{MAIN_SECTION, {{0, 0, 40225}, NULL}, NULL, cmdMoveItemEdge}, // Item edit: Grow left edge of items
 	{MAIN_SECTION, {{0, 0, 40226}, NULL}, NULL, cmdMoveItemEdge}, // Item edit: Shrink left edge of items
 	{MAIN_SECTION, {{0, 0, 40227}, NULL}, NULL, cmdMoveItemEdge}, // Item edit: Shrink right edge of items

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -391,7 +391,7 @@ const char* getFolderCompacting(MediaTrack* track) {
 	return ""; // Should never happen.
 }
 
-const char* getActionName(int command, KbdSectionInfo* section=nullptr, bool skipCategory=true) {
+const char* getActionName(int command, KbdSectionInfo* section, bool skipCategory) {
 	const char* name = kbd_getTextFromCmd(command, section);
 	if (skipCategory) {
 		const char* start;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -391,10 +391,10 @@ const char* getFolderCompacting(MediaTrack* track) {
 	return ""; // Should never happen.
 }
 
-void reportActionName(int command, KbdSectionInfo* section=NULL, bool skipCategory=true) {
+const char* getActionName(int command, KbdSectionInfo* section=nullptr, bool skipCategory=true) {
 	const char* name = kbd_getTextFromCmd(command, section);
-	const char* start;
 	if (skipCategory) {
+		const char* start;
 		// Skip the category before the colon (if any).
 		for (start = name; *start; ++start) {
 			if (*start == ':') {
@@ -403,9 +403,7 @@ void reportActionName(int command, KbdSectionInfo* section=NULL, bool skipCatego
 			}
 		}
 	}
-	ostringstream s;
-	s << name;
-	outputMessage(s);
+	return name;
 }
 
 bool isTrackMuted(MediaTrack* track) {
@@ -2936,16 +2934,7 @@ void cmdMoveItemEdge(Command* command) {
 	}
 	ostringstream s;
 	if(lastCommand != command->gaccel.accel.cmd) { 
-		const char* name = kbd_getTextFromCmd(command->gaccel.accel.cmd, nullptr);
-		const char* start;
-		// Skip the category before the colon (if any).
-		for (start = name; *start; ++start) {
-			if (*start == ':') {
-				name = start + 2;
-				break;
-			}
-		}
-		s<<name << " ";
+		s<< getActionName(command->gaccel.accel.cmd) << " ";
 		resetTimeCache();
 	}
 	double oldStart =GetMediaItemInfo_Value(item,"D_POSITION");
@@ -4297,7 +4286,7 @@ bool handleCommand(KbdSectionInfo* section, int command, int val, int valHw, int
 		} 
 		return true;
 	} else if (isShortcutHelpEnabled) {
-		reportActionName(command, section, false);
+		outputMessage(getActionName(command, section, false));
 		return true;
 	} else if (handlePostCommand(section->uniqueID, command, val, valHw, relMode,
 			hwnd)) {


### PR DESCRIPTION
reports the new position for the commands:
- Item edit: Move items/envelope points right
- Item edit: Move items/envelope points left
- Item edit: Move items/envelope points right by grid size
- Item edit: Move items/envelope points left by grid size

fixes #155 