### PR TITLE
Add feedback for commands that change preview volume in the media explorer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -441,6 +441,10 @@ FX: Toggle delta solo for last focused FX
 - Options: F1-F12 as step input mode
 - Edit: Toggle selection of all CC events under selected notes
 
+#### Media Explorer
+- Preview: decrease volume by 1 dB
+- Preview: increase volume by 1 dB
+
 ### Context Menus
 There are several context menus in REAPER, but some of them are difficult to access or not accessible at all from the keyboard.
 OSARA enables keyboard access for the track input, track area, track routing, item, ruler, envelope point and automation item context menus.

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2080,7 +2080,7 @@ PostCustomCommand POST_CUSTOM_COMMANDS[] = {
 };
 
 using MExplorerPostExecute = void (*)(int, HWND);
-map<int, MExplorerPostExecute> MExplorerPostCommands{
+map<int, MExplorerPostExecute> mExplorerPostCommands{
 	{42178, postMExplorerChangeVolume }, // Preview: decrease volume by 1 dB
 	{42177, postMExplorerChangeVolume}, // Preview: increase volume by 1 dB
 };
@@ -4256,8 +4256,8 @@ bool handlePostCommand(int section, int command, int val=0, int valHw=0,
 			return true;
 		}
 	} else if(section == MEDIA_EXPLORER_SECTION) {
-		const auto it = MExplorerPostCommands.find(command);
-		if(it != MExplorerPostCommands.end()){
+		const auto it = mExplorerPostCommands.find(command);
+		if(it != mExplorerPostCommands.end()){
 			isHandlingCommand = true;
 			SendMessage(hwnd, WM_COMMAND, command, 0);
 			it->second(command, hwnd);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1827,8 +1827,9 @@ void postToggleTakePreservePitch(int command) {
 
 void postMExplorerChangeVolume(int cmd, HWND hwnd) {
 	HWND w = GetDlgItem(hwnd, 1047);
-	char text[50];
-	if(!GetWindowText(w, text, ARRAYSIZE(text))) {
+	const int sz = 10;
+	char text[sz];
+	if(!GetWindowText(w, text ,sz)) {
 		return;
 	}
 	outputMessage(text);


### PR DESCRIPTION
There is no API for this, so it gets the text from the GUI.  Only tested on Windows, but the functions used all exist in swell; let's see what happens.

fixes #430 