### PR TITLE
Make ctrl+up, ctrl+down and ctrl+space work in list views

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2397,7 +2397,8 @@ LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		wParam != VK_APPS && wParam != VK_CONTROL &&
 				wParam != VK_F10 && wParam != VK_RETURN &&
 				wParam != VK_F6 && wParam != 'B' &&
-				wParam != VK_TAB && wParam != VK_DOWN)) {
+				wParam != VK_TAB && wParam != VK_DOWN &&
+				wParam != VK_UP && wParam != VK_SPACE)) {
 		// Return early if we're not interested in the key.
 		return CallNextHookEx(nullptr, code, wParam, lParam);
 	}
@@ -2494,6 +2495,12 @@ LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		if (maybeOpenFxPresetDialog()) {
 			return 1;
 		}
+	} else if(control && 
+		(wParam == VK_DOWN || wParam == VK_UP || wParam == VK_SPACE)
+		&& isListView(focus)
+	) {
+		SendMessage(focus, WM_KEYDOWN, wParam, lParam);
+		return 1;
 	}
 	return CallNextHookEx(nullptr, code, wParam, lParam);
 }


### PR DESCRIPTION
uses the keyboard hook to pass these keys directly to the control.  Allows multiple noncontiguous selection in the action list.

fixes: #697 