### PR TITLE
Add control of time selection, loop points and marker navigation from…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -505,8 +505,18 @@ The Filter field allows you to narrow the list to only contain parameters which 
 For example, if the full list contained "Volume" and "Pan" parameters and you type "vol" in the Filter field, the list will be narrowed to only show "Volume".
 Clearing the text in the Filter field shows the entire list.
 
-When you are done working with parameters, press the Close button.
-Alternatively, you can press enter or escape.
+When you are done working with parameters, press the Close button, enter or escape.
+Note that  if you press Escape to exit the dialog, the changes you've made will not be reverted.
+
+#### Controlling Transport and Selection in the Parameters dialog
+It is often useful to be able to audition parameter adjustments you're making in context.
+OSARA  makes it possible to adjust the context you're hearing without leaving the Parameters dialog.
+The following functionality is supported, albeit with some non-standard behaviour which is noted in parentheses:
+- Play/Stop (note: you must use Control+Space while inside the Parameters dialog)
+- Setting start and end of time slection and loop points
+- Function keys F1 through F12
+- The Control, Alt and Shift modifiers, or any combination thereof
+- Navigation of project markers, stretch markers and tempo time signature changes (note that the previous/next keys for marker navigation do not work when focus is in edit fields, so you can still type those characters in the Filter)
 
 ### Reading Current Peaks
 OSARA allows you to read the current audio peak for channels 1 and 2 of either the current or master tracks.

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -499,9 +499,21 @@ class ParamsDialog {
 			// Anything with both alt and shift.
 			(GetAsyncKeyState(VK_MENU) & 0x8000 &&
 				GetAsyncKeyState(VK_SHIFT) & 0x8000) ||
+			// Anything with both alt and control.
+			(GetAsyncKeyState(VK_MENU) & 0x8000 &&
+				GetAsyncKeyState(VK_CONTROL) & 0x8000) ||
+			// Anything with the alt key, but only if not in a text box.
+			(!isClassName(GetFocus(), "Edit") &&
+				GetAsyncKeyState(VK_MENU) & 0x8000) ||
 			// Anything with the control key, but only if not in a text box.
 			(!isClassName(GetFocus(), "Edit") &&
-				GetAsyncKeyState(VK_CONTROL) & 0x8000)
+				GetAsyncKeyState(VK_CONTROL) & 0x8000) ||
+			// Pass the semicolon key for marker navigation, but only if not in a text box.
+			(!isClassName(GetFocus(), "Edit") &&
+				GetAsyncKeyState(VK_OEM_1) & 0x8000) ||
+			// Pass the apostrophe key for marker navigation, but only if not in a text box.
+			(!isClassName(GetFocus(), "Edit") &&
+				GetAsyncKeyState(VK_OEM_7) & 0x8000)
 		) {
 			return -666; // Force to main window.
 		}


### PR DESCRIPTION
… within the Parameters dialog by passing keys through to main window.

This provides extra flexibility to adjust context without leaving the Parameters dialog. For maximum benefit, check "Stop playback at end of loop if repeat is disabled" in the Playback category, "Move edit cursor to start of time selection on time selection change" and "Link loop points to time selection" in the Editing Behavior category of Reaper Prefs.

Tbh I don't know if it addresses any specific open issues, the ideas came from a conversation with @jennykbrennan, I just ran at it while the motivation was strong.

Marking as draft for now, this should definitely be tested on both platforms. I dabbled with stuff that I don't fully understand yet, but it seems solid here.