### PR TITLE
Parameters dialog: Pass most keys through to REAPER's main window.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -533,19 +533,31 @@ class ParamsDialog {
 			// Let REAPER handle the space key so control+space works.
 			return 0; // Not interested.
 		}
-		if (
-			// A function key.
-			(VK_F1 <= msg->wParam && msg->wParam <= VK_F12) ||
-			// Anything with both alt and shift.
-			(GetAsyncKeyState(VK_MENU) & 0x8000 &&
-				GetAsyncKeyState(VK_SHIFT) & 0x8000) ||
-			// Anything with the control key, but only if not in a text box.
-			(!isClassName(GetFocus(), "Edit") &&
-				GetAsyncKeyState(VK_CONTROL) & 0x8000)
-		) {
-			return -666; // Force to main window.
+		if (msg->hwnd == dialog->paramCombo ||
+				isClassName(GetFocus(), "Edit")) {
+			// In text boxes and combo boxes, we only allow specific keys through to
+			// the main section.
+			if (
+				// A function key.
+				(VK_F1 <= msg->wParam && msg->wParam <= VK_F12) ||
+				// Anything with both alt and shift.
+				(GetAsyncKeyState(VK_MENU) & 0x8000 &&
+					GetAsyncKeyState(VK_SHIFT) & 0x8000)
+			) {
+				return -666; // Force to main window.
+			}
+			// Anything else must go to our window so the user can interact with the
+			// control.
+			return -1; // Pass to our window.
 		}
-		return -1; // Pass to our window.
+		switch (msg->wParam) {
+			case VK_TAB:
+			case VK_RETURN:
+			case VK_ESCAPE:
+				// These keys are required to interact with the dialog.
+				return -1; // Pass to our window.
+		}
+		return -666; // Force to main window.
 	}
 
 	~ParamsDialog() {


### PR DESCRIPTION
Previously, we only passed specific keys through to the main window.
Now, we do the inverse, capturing only specific keys for the Parameters dialog and passing the rest through to the main window.
The combo box and text boxes are still exceptions, where we only pass specific keys to the main window to ensure the user can interact with the control properly.
Practically speaking, this means users can access many more main window actions when focused on the slider or buttons.

This is yet another take on #700 and #701. It's less permissive than those in that it still doesn't allow marker navigation while in the combo box, which I think is a risky slippery slope. On the flip side, it doesn't require global bindings.

@ScottChesworth , @RDMurray , thoughts appreciated.

Fixes #784.