### PR TITLE
Control+tab/control+shift+tab anywhere in the Parameters dialog now move to the next/previous parameter.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -505,6 +505,8 @@ The Filter field allows you to narrow the list to only contain parameters which 
 For example, if the full list contained "Volume" and "Pan" parameters and you type "vol" in the Filter field, the list will be narrowed to only show "Volume".
 Clearing the text in the Filter field shows the entire list.
 
+As an alternative to using the Parameter combo box, you can press control+tab or control+shift+tab anywhere in the dialog to move to the next or previous parameter, respectively.
+
 When you are done working with parameters, press the Close button.
 Alternatively, you can press enter or escape.
 


### PR DESCRIPTION
I kinda hate this PR. It's a horrible hack that offends me on multiple levels and I feel dirty having written it. Still, I guess I can see how it might be useful sometimes.

It's very possible it won't work with JAWS, though. That will need testing. If it doesn't, there's probably nothing I can do about it.

Fixes #691.