### PR TITLE
When the Parameter combo box in the Parameters dialog gets focus, rebuild the parameter list.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -298,6 +298,7 @@ class ParamsDialog {
 	unique_ptr<ParamSource> source;
 	HWND dialog;
 	HWND paramCombo;
+	WNDPROC paramComboOrigProc;
 	HWND slider;
 	HWND valueEdit;
 	HWND valueLabel;
@@ -459,6 +460,20 @@ class ParamsDialog {
 				}
 		}
 		return FALSE;
+	}
+
+	static INT_PTR CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam,
+		LPARAM lParam
+	) {
+		ParamsDialog* dialog = (ParamsDialog*)GetWindowLongPtr(GetParent(hwnd),
+			GWLP_USERDATA);
+		if (msg == WM_SETFOCUS && dialog && hwnd == dialog->paramCombo) {
+			// Changing a param value might update param names; e.g. changing the
+			// band type in ReaEq.
+			dialog->updateParamList();
+			return 0;
+		}
+		return CallWindowProc(dialog->paramComboOrigProc, hwnd, msg, wParam, lParam);
 	}
 
 	accelerator_register_t accelReg;
@@ -634,6 +649,8 @@ class ParamsDialog {
 		SetWindowText(this->dialog, this->source->getTitle().c_str());
 		this->paramCombo = GetDlgItem(this->dialog, ID_PARAM);
 		WDL_UTF8_HookComboBox(this->paramCombo);
+		this->paramComboOrigProc = (WNDPROC)SetWindowLongPtr(this->paramCombo,
+			GWLP_WNDPROC, (LONG_PTR)this->wndProc);
 		this->slider = GetDlgItem(this->dialog, ID_PARAM_VAL_SLIDER);
 		// We need to do exotic stuff with this slider that we can't support on Mac:
 		// 1. Custom step values (TBM_SETLINESIZE, TBM_SETPAGESIZE).


### PR DESCRIPTION

This deals with cases where changing a parameter value also changes parameter names; e.g. changing the bad type in ReaEq.
Fixes #706.

This is a fairly naive solution in that it doesn't bother to keep track of whether a parameter value has actually changed. Thus, it rebuilds the parameter list more often than it strictly needs to. That said, unless this actually causes performance problems for plugins with large numbers of parameters, I'd prefer not to complicate the code here. It should be possible if this does cause problems, though.

Either way, this needs testing on plugins with large numbers of parameters.