### PR TITLE
Fix bug in PR #698 that prevented Ctrl+up/down from reordering the second list in the custom action edit dialog. fixes: #704

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2498,6 +2498,8 @@ LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 	} else if(control && 
 		(wParam == VK_DOWN || wParam == VK_UP || wParam == VK_SPACE)
 		&& isListView(focus)
+		// exclude the second list in the Edit custom action dialog because Ctrl+up/down reorder items.
+		&& GetWindowLong(focus, GWL_ID) != 1322
 	) {
 		SendMessage(focus, WM_KEYDOWN, wParam, lParam);
 		return 1;


### PR DESCRIPTION
fixes: #704 