### PR TITLE
Avoid unintended FX parameter change

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -390,7 +390,7 @@ class ParamsDialog {
 		char rawText[30];
 		if (GetDlgItemText(dialog, ID_PARAM_VAL_EDIT, rawText, sizeof(rawText)) == 0)
 			return;
-		if (this->param->getValueForEditing() == string(rawText))
+		if (this->param->getValueForEditing().compare(rawText) == 0)
 			return;
 		this->param->setValueFromEdited(rawText);
 		this->val = this->param->getValue();

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -390,6 +390,8 @@ class ParamsDialog {
 		char rawText[30];
 		if (GetDlgItemText(dialog, ID_PARAM_VAL_EDIT, rawText, sizeof(rawText)) == 0)
 			return;
+		if (this->param->getValueForEditing() == string(rawText))
+			return;
 		this->param->setValueFromEdited(rawText);
 		this->val = this->param->getValue();
 		this->updateValue();


### PR DESCRIPTION
In FX parameters dialog, edit control always set parameter of focus kill. Since precision of displayed number is fixed to 4, that can change actual parameter value even in case the text was not modified.

For example in ReqEQ if band frequency was 1000 Hz it is changed to 999.7 Hz.

This PR prevents parameter editing in case the text was not modified.