### PR TITLE
Fix media explorer volume feedback in Reaper 6.65 and above, fixes #781

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1840,7 +1840,10 @@ void postToggleTakePreservePitch(int command) {
 }
 
 void postMExplorerChangeVolume(int cmd, HWND hwnd) {
-	HWND w = GetDlgItem(hwnd, 1047);
+	HWND w = GetDlgItem(hwnd, 997);
+	if(!w) {// support Reaper versions before 6.65
+		w = GetDlgItem(hwnd, 1047);
+	}
 	const int sz = 10;
 	char text[sz];
 	if(!GetWindowText(w, text ,sz)) {


### PR DESCRIPTION
fix #781  by checking for the control id of the new edit control for media explorer volume in Reaper 6.65.