### PR TITLE
When OSARA's Report time selection command is pressed twice, include all selections, not just the focus.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -744,7 +744,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Report tracks with phase inverted: Alt+Shift+F9
  - Pressing this twice will display the information in a dialog with a text box for easy review.
 - OSARA: Report track/item/time selection (depending on focus): Control+Shift+Space
- - Pressing this twice will display the information in a dialog with a text box for easy review.
+ - Pressing this twice will display the information for all selections (not just the focus) in a dialog with a text box for easy review.
 - OSARA: Remove items/tracks/contents of time selection/markers/envelope points (depending on focus): Delete
 - OSARA: Report edit/play cursor position and transport state: Control+Shift+J
  - If the ruler unit is set to Measures.Beats / Minutes:Seconds, Pressing this once will report the time in measures.beats, while pressing it twice will report the time in minutes:seconds .


### PR DESCRIPTION
Fixes #456.