### PR TITLE
Fix "OSARA: Focus event nearest edit cursor"

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -196,6 +196,7 @@
 #define REAPERAPI_WANT_MIDI_GetEvt
 #define REAPERAPI_WANT_TrackFX_GetParamFromIdent
 #define REAPERAPI_WANT_TrackFX_GetNamedConfigParm
+#define REAPERAPI_WANT_GetItemStateChunk
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
Reported on RWP, Control+f focused the wrong event in the list because the event positions in the event list are based on the start of the midi source, and Osara currently always bases positions on project time.

This assumes that PPQ is set to the default of 960. is it common for people to change it? I suspect not.

On a related subject, Reaper now seems to cause the edit cursor to follow focus in the event list by default. I think this makes the option in Osara preferences redundant. The only thing it does now is to automatically focus the nearest event when switching to the event list. Should we remove it?