### PR TITLE
Revert let edit cursor follow focus in MIDI event list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -714,8 +714,6 @@ The dialog contains the following options:
  When disabled, track numbers will not be reported except for unnamed tracks.
 - Report FX when moving to tracks/takes: When enabled, OSARA will report the names of any effects on a track or take when you move to it.
 - Report MIDI notes in MIDI editor: When enabled, OSARA will report the names of individual MIDI notes and the number of notes in a chord.
-- Edit cursor follows focus in MIDI event list: When enabled, the edit cursor in the MIDI  editor event list wil follow along with the focused event.
- This option is only available on Windows.
 - Report changes made via control surfaces: When enabled, OSARA will report track selection changes, parameter changes, etc. made using a control surface.
 
 When you are done, press the OK button to accept any changes or the Cancel button to discard them.

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1541,26 +1541,13 @@ void cmdMidiFilterWindow(Command *command) {
 
 void maybeHandleEventListItemFocus(HWND hwnd, long childId) {
 	bool shouldPreviewNotes = GetToggleCommandState2(SectionFromUniqueID(MIDI_EVENT_LIST_SECTION), 40041);  // Options: Preview notes when inserting or editing
-	if (!shouldPreviewNotes && !settings::editCursorFollowsEventListFocus) {
-		return;
-	}
-	if (childId == CHILDID_SELF) {
-		// Focus is set to the list, not to an item within the list.
-		if (settings::editCursorFollowsEventListFocus) {
-			focusNearestMidiEvent(hwnd);
-		}
+	if (!shouldPreviewNotes) {
 		return;
 	}
 	HWND editor = MIDIEditor_GetActive();
 	assert(editor == GetParent(hwnd));
 	auto focused = ListView_GetNextItem(hwnd, -1, LVNI_FOCUSED);
 	auto event = MidiEventListData::get(editor, focused);
-	if (settings::editCursorFollowsEventListFocus) {
-		SetEditCurPos(event.position , true, false);
-	}
-	if (!shouldPreviewNotes) {
-		return;
-	}
 	// Check whether this is a note
 	if (event.length == -1) {
 		// No Note

--- a/src/settings.h
+++ b/src/settings.h
@@ -41,11 +41,6 @@ BoolSetting(reportFx,
 BoolSetting(reportNotes,
 	"Report MIDI &notes in MIDI editor",
 	true)
-#ifdef _WIN32
-BoolSetting(editCursorFollowsEventListFocus,
-	"Edit cursor follows focus in MIDI &event list",
-	false)
-#endif
 BoolSetting(reportSurfaceChanges,
 	"Report changes made via &control surfaces",
 	false)


### PR DESCRIPTION
Not sure when, but this became obsolete since REAPER does this natively. See https://github.com/jcsteh/osara/pull/599#issuecomment-1241954806