### PR TITLE
Fix F6 in the FX window to work with non-english translations

### DIFF
--- a/src/fxChain.cpp
+++ b/src/fxChain.cpp
@@ -53,17 +53,9 @@ void shortenFxName(const char* name, ostringstream& s) {
 
 bool maybeSwitchToFxPluginWindow() {
 	HWND window = GetForegroundWindow();
-	char name[8];
-	if (GetWindowText(window, name, sizeof(name)) == 0)
-		return false;
-	if (strncmp(name, "FX: ", 4) != 0 && // FX chain window
-		// floating FX window, for different plug-in types
-		strncmp(name, "DX: ", 4) != 0 &&
-		strncmp(name, "VST: ", 5) != 0 &&
-		strncmp(name, "VSTi: ", 6) != 0 &&
-		strncmp(name, "VST3: ", 6) != 0 &&
-		strncmp(name, "VST3i: ", 7) != 0
-	) {
+	const unsigned int fxFocus = GetFocusedFX2(nullptr, nullptr, nullptr);
+	const bool isFxWindow = (fxFocus) && !(fxFocus & 4);
+	if (!isFxWindow) {
 		return false;
 	}
 	// Descend. Observed as the first or as the last.
@@ -72,6 +64,7 @@ bool maybeSwitchToFxPluginWindow() {
 	}
 	// This is a property page containing the plugin window among other things.
 	// set property page name, to avoid CPU/PDC label audition after switching
+	char name[8];
 	if (GetWindowText(window, name, sizeof(name)) == 0) {
 		SetWindowText(window, " ");
 	}

--- a/src/osara.h
+++ b/src/osara.h
@@ -197,7 +197,6 @@
 #define REAPERAPI_WANT_MIDI_GetEvt
 #define REAPERAPI_WANT_TrackFX_GetParamFromIdent
 #define REAPERAPI_WANT_TrackFX_GetNamedConfigParm
-#define REAPERAPI_WANT_LocalizeString
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -183,6 +183,7 @@
 #define REAPERAPI_WANT_GetToggleCommandState2
 #define REAPERAPI_WANT_SectionFromUniqueID
 #define REAPERAPI_WANT_GetFocusedFX
+#define REAPERAPI_WANT_GetFocusedFX2
 #define REAPERAPI_WANT_GetTake
 #define REAPERAPI_WANT_GetTrackUIMute
 #define REAPERAPI_WANT_GetResourcePath
@@ -196,6 +197,7 @@
 #define REAPERAPI_WANT_MIDI_GetEvt
 #define REAPERAPI_WANT_TrackFX_GetParamFromIdent
 #define REAPERAPI_WANT_TrackFX_GetNamedConfigParm
+#define REAPERAPI_WANT_LocalizeString
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
Using F6 to focus the plugin UI didn't work with some Reaper langpacks due to relying on the window title. Fixes #792 
