### PR TITLE
Fix clang warnings about unqualified std::move

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -625,7 +625,7 @@ class ParamsDialog {
 
 	public:
 
-	ParamsDialog(unique_ptr<ParamSource> source): source(move(source)) {
+	ParamsDialog(unique_ptr<ParamSource> source): source(std::move(source)) {
 		this->paramCount = this->source->getParamCount();
 		if (this->paramCount == 0) {
 			delete this;
@@ -1130,7 +1130,7 @@ void cmdParamsFocus(Command* command) {
 			MediaItem_Take* take = GetTake(item, takeNum);
 			source = make_unique<FxParams<MediaItem_Take>>(take, "TakeFX", fx);
 		}
-		new ParamsDialog(move(source));
+		new ParamsDialog(std::move(source));
 		return;
 	}
 
@@ -1152,7 +1152,7 @@ void cmdParamsFocus(Command* command) {
 		default:
 			return;
 	}
-	new ParamsDialog(move(source));
+	new ParamsDialog(std::move(source));
 }
 
 typedef vector<pair<int, string>> FxList;
@@ -1236,7 +1236,7 @@ void fxParams_begin(ReaperObj* obj, const string& apiPrefix) {
 	}
 
 	auto source = make_unique<FxParams<ReaperObj>>(obj, apiPrefix, fx);
-	new ParamsDialog(move(source));
+	new ParamsDialog(std::move(source));
 }
 
 void cmdFxParamsFocus(Command* command) {

--- a/src/uia.cpp
+++ b/src/uia.cpp
@@ -195,7 +195,7 @@ bool terminateUia() {
 	if (uiaProvider) {
 		// Null out uiaProvider so it can't be returned by WM_GETOBJECT during
 		// disconnection.
-		CComPtr<IRawElementProviderSimple> tmpProv = move(uiaProvider);
+		CComPtr<IRawElementProviderSimple> tmpProv = std::move(uiaProvider);
 		uiaProvider = nullptr;
 		uiaCore->DisconnectProvider(tmpProv);
 	}


### PR DESCRIPTION
The version of clang in visual studio 17.4.1 warns about unqualified calls to std::move().
[See this discussion for details](https://reviews.llvm.org/D119670)

This raises the question, should we get rid of "using namespace std" which is considered bad practise? I totally understand it's advantage: code cluttered with std:: is harder to read.