### PR TITLE
When moving between chords in the MIDI editor, don't report note counts if report scrubbing is disabled.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -992,7 +992,7 @@ void moveToChord(int direction, bool clearSelection=true, bool select=true) {
 	if (!select && !isNoteSelected(take, chord.first.getIndex())) {
 		s << translate("unselected") << " ";
 	}
-	if (settings::reportNotes) {
+	if (settings::reportNotes && settings::reportScrub) {
 		int count = chord.second - chord.first;
 		// Translators: used when reporting the number of notes in a chord.
 		// {} will be replaced by the number of notes. E.g. "3 notes"


### PR DESCRIPTION
This is regarding https://github.com/jcsteh/osara/commit/973b57fa50dd19f4be72707ba73c0eb2ffeac587#commitcomment-92955201.
I don't entirely understand what you're saying, @ScottChesworth , mostly because i can't be bothered fully getting my head around it. If I've understood you correctly, the change you want is a single line of code. The easiest way to be sure is for you to test this PR. :)