### PR TITLE
Only eat WM_KEYDOWN VK_CONTROL messages when used to cancel a note preview

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2520,8 +2520,8 @@ LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 	if (wParam == VK_CONTROL) {
 		if (cancelPendingMidiPreviewNotesOff()) {
 			previewNotesOff(true);
+			return 1;
 		}
-		return 1;
 	}
 	HWND window;
 	if (isContextMenu && (window = getSendContainer(focus))) {


### PR DESCRIPTION
OSARA currently unconditionally prevent the system from passing any `WM_KEYDOWN` messages for the Control key to the rest of the hook chain or the target window procedure.

This affects ReaImGui which expects to receive these messages. (The issue can be duplicated via the ReaImGui_Demo.lua script under Inputs, Navigation & Focus -> Keyboard, Gamepad & Navigation State: after installing OSARA, the LeftCtrl and RightCtrl keys are not triggered.)