### PR TITLE
report nested folders, fixes #763

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -207,6 +207,7 @@
 #define REAPERAPI_WANT_FreeHeapPtr
 #define REAPERAPI_WANT_TimeMap2_timeToQN
 #define REAPERAPI_WANT_MIDI_GetGrid
+#define REAPERAPI_WANT_GetParentTrack
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -429,6 +429,19 @@ const char* getFolderCompacting(MediaTrack* track) {
 	return ""; // Should never happen.
 }
 
+int getTrackDepth(MediaTrack* track){
+	int count = CountTracks(nullptr);
+	int depth = 0;
+	for (int i = 0; i<count; i++){
+		MediaTrack* track_ = GetTrack(nullptr, i);
+		if (track_ == track) {
+			break;
+		}
+		depth += (int)GetMediaTrackInfo_Value(track_, "I_FOLDERDEPTH");
+	}
+	return depth;
+}
+
 const char* getActionName(int command, KbdSectionInfo* section, bool skipCategory) {
 	const char* name = kbd_getTextFromCmd(command, section);
 	if (skipCategory) {
@@ -787,6 +800,11 @@ void postGoToTrack(int command, MediaTrack* track) {
 			// There's no name and track number reporting is disabled. We report the
 			// number in lieu of the name.
 			s << trackNum;
+		}
+		int level = getTrackDepth(track);
+		if (level>0) {
+			separate();
+			s << "level " << level;
 		}
 		if (armed && autoArm) {
 			separate();

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -419,7 +419,7 @@ string formatFolderState(MediaTrack* track) {
 		s << translate("end of folder");
 		// find the folder being ended by this track
 		MediaTrack* folderTrack = track;
-		for(int i = 0; i<(-state); ++i) {
+		for(int i = state; i<0; ++i) {
 			folderTrack = GetParentTrack(folderTrack); 
 		}
 		if(!folderTrack) { // shouldn't happen

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -454,19 +454,6 @@ const char* getFolderCompacting(MediaTrack* track) {
 	return ""; // Should never happen.
 }
 
-int getTrackDepth(MediaTrack* track){
-	int count = CountTracks(nullptr);
-	int depth = 0;
-	for (int i = 0; i<count; i++){
-		MediaTrack* track_ = GetTrack(nullptr, i);
-		if (track_ == track) {
-			break;
-		}
-		depth += (int)GetMediaTrackInfo_Value(track_, "I_FOLDERDEPTH");
-	}
-	return depth;
-}
-
 const char* getActionName(int command, KbdSectionInfo* section, bool skipCategory) {
 	const char* name = kbd_getTextFromCmd(command, section);
 	if (skipCategory) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -408,6 +408,9 @@ const string formatFolderState(MediaTrack* track) {
 	if (state == 0) {
 		// Translators: A track which isn't a folder.
 		s << translate("track");
+	} else if (state == 1 && GetMediaTrackInfo_Value(track, "P_PARTRACK")) {
+		// Translators: A track which is a nested folder.
+		s << translate("nested folder");
 	} else if (state == 1) {
 		// Translators: A track which is a folder.
 		s << translate("folder");


### PR DESCRIPTION
Report when a folder is nested inside another folder. For tracks that close a folder, reports the name (and number if report track numbers is enabled) of the folder being closed. E.G.:
* 1 open folder instruments
* 2 open nested folder strings
* ...
* 10 violin end of folder 2 strings
* ...
* 20 end of folder 1 instruments

