### PR TITLE
Commented out call to translateDialog in peakWatcher.cpp 

### DIFF
--- a/src/peakWatcher.cpp
+++ b/src/peakWatcher.cpp
@@ -641,7 +641,7 @@ class Dialog {
 			MAKEINTRESOURCE(ID_PEAK_WATCHER_DLG), GetForegroundWindow(),
 			Dialog::dialogProc);
 		SetWindowLongPtr(this->dialog, GWLP_USERDATA, (LONG_PTR)this);
-		translateDialog(this->dialog);
+// 		translateDialog(this->dialog);
 		s << translate_ctxt("Peak Watcher", "Peak Watcher") << ": ";
 		describeTarget(target, s);
 		SetWindowText(this->dialog, s.str().c_str());


### PR DESCRIPTION
for GUI comparison, as per Jamie's suggestion in #861