### PR TITLE
Don't pass page keys to Transient Sensitivity dialog, 

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3854,8 +3854,6 @@ int transDetect_translateAccel(MSG* msg, accelerator_register_t* accelReg) {
 		case VK_LEFT:
 		case VK_UP:
 		case VK_DOWN:
-		case VK_PRIOR:
-		case VK_NEXT:
 		case VK_HOME:
 		case VK_END:
 		case VK_SPACE:


### PR DESCRIPTION
as they don't serve any useful purpose within the dialog, and our usual mappings can still be used if these are allowed to reach main section.