### PR TITLE
Add actions to move from play cursor config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -649,7 +649,7 @@ The dialog contains the following options:
  When this is disabled, OSARA will only report the part of the time that changed.
  Using the same example, OSARA would report only "beat 2".
 - Move relative to the play cursor for time movement commands during playback: When enabled, time movement commands such as scrubbing or moving by bar/beat will move from where you are currently playing, rather than relative to the edit cursor.
-- Report markers during playback: When enabled, project markers and regions will be reported during playback as the cursor passes them.
+- Report markers and regions during playback: When enabled, project markers and regions will be reported during playback as the cursor passes them.
 - Report transport state (play, record, etc.): When enabled, OSARA will report the transport state when you change it; e.g. if you begin playing or recording.
 - Report track numbers: When enabled, OSARA will report track numbers as well as track names.
  When disabled, track numbers will not be reported except for unnamed tracks.

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2170,6 +2170,10 @@ const set<int> MOVE_FROM_PLAY_CURSOR_COMMANDS = {
 	41043, // Go back one measure
 	41044, // Go forward one beat
 	41045, // Go back one beat
+	41041, // Move edit cursor to start of current measure
+	41040, // Move edit cursor to start of next measure
+	40646, // View: Move cursor left to grid division
+40647, // View: Move cursor right to grid division
 };
 
 map<int, PostCommandExecute> midiPostCommandsMap;

--- a/src/settings.h
+++ b/src/settings.h
@@ -27,7 +27,7 @@ BoolSetting(moveFromPlayCursor,
 	"&Move relative to the play cursor for time movement commands during playback",
 	false)
 BoolSetting(reportMarkersWhilePlaying,
-	"Report mar&kers during playback",
+	"Report mar&kers and regions during playback",
 	false)
 BoolSetting(reportTransport,
 	"Report &transport state (play, record, etc.)",


### PR DESCRIPTION
When "Move relative to the play cursor for time movement commands during playback" option is checked in OSARA Config, now "Move edit cursor to start of current measure", "Move edit cursor to start of next measure", "View: Move cursor left to grid division" and "View: Move cursor right to grid division" respect that.