### PR TITLE
When moving the pitch cursor, the preview now respects the configured insertion note length.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1123,7 +1123,15 @@ void postMidiMovePitchCursor(int command) {
 	int pitch = MIDIEditor_GetSetting_int(editor, "active_note_row");
 	int chan = MIDIEditor_GetSetting_int(editor, "default_note_chan");
 	int vel = MIDIEditor_GetSetting_int(editor, "default_note_vel");
-	previewNotes(take, {{chan, pitch, vel}});
+	double start = GetCursorPosition();
+	double startQn = TimeMap2_timeToQN(nullptr, start);
+	double lenQn;
+	double gridQn = MIDI_GetGrid(take, nullptr, &lenQn);
+	if (lenQn == 0) {
+		lenQn = gridQn;
+	}
+	double end = TimeMap2_QNToTime(nullptr, startQn + lenQn);
+	previewNotes(take, {{chan, pitch, vel, -1, start, end}});
 	if (settings::reportNotes) {
 		outputMessage(getMidiNoteName(take, pitch, chan));
 	}

--- a/src/osara.h
+++ b/src/osara.h
@@ -205,6 +205,8 @@
 #define REAPERAPI_WANT_GetSetMediaItemTakeInfo_String
 #define REAPERAPI_WANT_GetSetObjectState
 #define REAPERAPI_WANT_FreeHeapPtr
+#define REAPERAPI_WANT_TimeMap2_timeToQN
+#define REAPERAPI_WANT_MIDI_GetGrid
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
Fixes #884.
As is so often the case with REAPER, this was trivial once I figured out what pieces in the massive jigsaw puzzle needed to fit in the right places. Of course, figuring that out is often non-trivial...