### PR TITLE
Fix take volume in Parameters dialog when take polarity is flipped.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -170,10 +170,18 @@ class ReaperObjVolParam: public ReaperObjParam {
 		this->step = 0.002;
 		this->largeStep = 0.1;
 		this->isEditable = true;
+		if (this->getValue() < 0) {
+			// Take volume raw values are negative when the polarity is flipped.
+			this->flipSign = true;
+		}
 	}
 
 	double getValue() {
-		return *(double*)this->provider.getSetValue(nullptr);
+		double result = *(double*)this->provider.getSetValue(nullptr);
+		if (this->flipSign) {
+			result = -result;
+		}
+		return result;
 	}
 
 	string getValueText(double value) {
@@ -187,7 +195,12 @@ class ReaperObjVolParam: public ReaperObjParam {
 	}
 
 	void setValue(double value) {
-		this->provider.getSetValue((void*)&value);
+		if (this->flipSign) {
+			double flipped = -value;
+			this->provider.getSetValue((void*)&flipped);
+		} else {
+			this->provider.getSetValue((void*)&value);
+		}
 	}
 
 	void setValueFromEdited(const string& text) {
@@ -202,6 +215,9 @@ class ReaperObjVolParam: public ReaperObjParam {
 	static unique_ptr<Param> make(ReaperObjParamProvider& provider) {
 		return make_unique<ReaperObjVolParam>(provider);
 	}
+
+	private:
+	bool flipSign = false;
 };
 
 class ReaperObjPanParam: public ReaperObjParam {


### PR DESCRIPTION
In this case, the raw value is negative. We need to flip it accordingly when both retrieving and setting it. It was easiest to do this in ReaperObjVolParam, even though this only affects takes. We check whether the current raw value is negative during construction and set a flag so we know whether the sign needs to be flipped thereafter. This avoids checks each time we set the value; i.e. we only check this the first time the parameter is constructed.
Fixes #891.