### PR TITLE
Fix focusing the MIDI Filter Events window in non-English REAPER.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1613,7 +1613,8 @@ void cmdMidiFilterWindow(Command *command) {
 	HWND editor = MIDIEditor_GetActive();
 	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
 	// TODO: we could also check the command state was "off", to skip searching otherwise
-	HWND filter = FindWindow(WC_DIALOG, "Filter Events");
+	HWND filter = FindWindowW(L"#32770",
+		widen(LocalizeString("Filter Events", "midi_DLG_128", 0)).c_str());
 	if (filter && (filter != GetFocus())) {
 		SetFocus(filter); // focus the window
 	}

--- a/src/osara.h
+++ b/src/osara.h
@@ -208,6 +208,7 @@
 #define REAPERAPI_WANT_TimeMap2_timeToQN
 #define REAPERAPI_WANT_MIDI_GetGrid
 #define REAPERAPI_WANT_GetParentTrack
+#define REAPERAPI_WANT_LocalizeString
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
The only way we can currently find this window is via its title. Previously, this title was a hard-coded English only string. Instead, we now use REAPER's own localisation functionality to get the string from the REAPER lang pack.
Fixes #922.