### PR TITLE
Make shift+space toggle item selection in the MIDI Editor Event List.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1648,6 +1648,16 @@ void maybeHandleEventListItemFocus(HWND hwnd, long childId) {
 	previewNotes(take, {note});
 }
 
+void toggleListViewItemSelection(HWND list) {
+	const int item = ListView_GetNextItem(list, -1, LVNI_FOCUSED);
+	if (item == -1) {
+		return;
+	}
+	UINT prevState = ListView_GetItemState(list, item, LVIS_SELECTED);
+	ListView_SetItemState(list, item,
+		prevState == LVIS_SELECTED? 0 : LVIS_SELECTED, LVIS_SELECTED);
+}
+
 #endif // _WIN32
 
 void postMidiChangeVelocity(int command) {

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -54,6 +54,7 @@ void cmdMidiNoteSplitOrJoin(Command* command);
 void cmdFocusNearestMidiEvent(Command* command);
 void cmdMidiFilterWindow(Command* command);
 void maybeHandleEventListItemFocus(HWND hwnd, long childId);
+void toggleListViewItemSelection(HWND list);
 #endif
 
 void postMidiChangeVelocity(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2670,8 +2670,19 @@ LRESULT CALLBACK keyboardHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		&& isListView(focus)
 		// exclude the second list in the Edit custom action dialog because Ctrl+up/down reorder items.
 		&& GetWindowLong(focus, GWL_ID) != 1322
+		// Exclude control+space in the MIDI Editor Event List because play/pause is
+		// super useful there.
+		&& !(isMidiEditorEventListView(focus) && wParam == VK_SPACE)
 	) {
+		// Send control+upArrow, control+downArrow and control+space to most
+		// SysListView32 controls to allow for non-contiguous item selection.
 		SendMessage(focus, WM_KEYDOWN, wParam, lParam);
+		return 1;
+	}
+	if (shift && !control && !alt && wParam == VK_SPACE &&
+			isMidiEditorEventListView(focus)) {
+		// In the MIDI Editor Event List, make shift+space toggle selection.
+		toggleListViewItemSelection(focus);
 		return 1;
 	}
 	return CallNextHookEx(nullptr, code, wParam, lParam);


### PR DESCRIPTION
This allows control+space to play/pause as usual.
Fixes #869.