### PR TITLE
When a container is focused in an FX chain list, pressing f6 now focuses the container's FX list.

### DIFF
--- a/src/fxChain.cpp
+++ b/src/fxChain.cpp
@@ -102,11 +102,23 @@ void shortenFxName(const char* name, ostringstream& s) {
 #ifdef _WIN32
 
 bool maybeSwitchToFxPluginWindow() {
-	HWND window = GetForegroundWindow();
 	MediaTrack* track;
 	MediaItem_Take* take;
 	int fx;
 	if (!getFocusedFx(&track, &take, &fx)) {
+		return false;
+	}
+	// Find the nearest ancestor FX chain parent window. This might be the top
+	// level FX chain or it might be a container. This allows f6 to focus FX
+	// inside a focused container.
+	HWND window = GetFocus();
+	do {
+		window = GetParent(window);
+		if (isClassName(window, "#32770")) {
+			break;
+		}
+	} while (window);
+	if (!window) {
 		return false;
 	}
 	// Descend. Observed as the first or as the last.

--- a/src/fxChain.cpp
+++ b/src/fxChain.cpp
@@ -114,7 +114,7 @@ bool maybeSwitchToFxPluginWindow() {
 	HWND window = GetFocus();
 	do {
 		window = GetParent(window);
-		if (isClassName(window, "#32770")) {
+		if (isClassName(window, WCS_DIALOG)) {
 			break;
 		}
 	} while (window);
@@ -122,7 +122,7 @@ bool maybeSwitchToFxPluginWindow() {
 		return false;
 	}
 	// Descend. Observed as the first or as the last.
-	if (!(window = FindWindowExA(window, nullptr, "#32770", nullptr))) {
+	if (!(window = FindWindowExA(window, nullptr, WCS_DIALOG, nullptr))) {
 		return false;
 	}
 	// Check whether this is an FX container.
@@ -145,11 +145,7 @@ bool maybeSwitchToFxPluginWindow() {
 	// Can not just search, we do not know the class nor name.
 	if (!(window = GetWindow(window, GW_CHILD)))
 		return false;
-	char classname[16];
-	if (!GetClassName(window, classname, sizeof(classname))) {
-		return false;
-	}
-	if (!strcmp(classname, "ComboBox")) {
+	if (isClassName(window, "ComboBox")) {
 		// Plugin window should be the last.
 		if (!(window = GetWindow(window, GW_HWNDLAST))) {
 			return false;

--- a/src/osara.h
+++ b/src/osara.h
@@ -221,6 +221,8 @@ const int MEDIA_EXPLORER_SECTION = 32063;
 static bool bFalse = false;
 static bool bTrue = true;
 
+extern const char* WCS_DIALOG;
+
 typedef struct Command {
 	int section;
 	gaccel_register_t gaccel;

--- a/src/osara.h
+++ b/src/osara.h
@@ -209,6 +209,7 @@
 #define REAPERAPI_WANT_MIDI_GetGrid
 #define REAPERAPI_WANT_GetParentTrack
 #define REAPERAPI_WANT_LocalizeString
+#define REAPERAPI_WANT_TakeFX_GetNamedConfigParm
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2388,6 +2388,8 @@ bool showReaperContextMenu(const int menu) {
 	return false;
 }
 
+const char* WCS_DIALOG = "#32770";
+
 bool isClassName(HWND hwnd, string className) {
 	char buffer[50];
 	if (GetClassName(hwnd, buffer, sizeof(buffer)) == 0) {


### PR DESCRIPTION
Fixes #947.