### PR TITLE
very Experimental support for fixed lanes

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4619,7 +4619,7 @@ void cmdOpenDoc(Command* command) {
 void MoveToFixedLane (int direction) {
 	MediaTrack* track = GetLastTouchedTrack();
 	if (getTrackFreeMode(track) != FreeMode::fixed) {
-		outputMessage("Track not in fixed lane mode");
+		outputMessage(translate("Track not in fixed lane mode"));
 		return;
 	}
 	int laneCount = (int)GetMediaTrackInfo_Value(track, "I_NUMFIXEDLANES");
@@ -4630,7 +4630,11 @@ void MoveToFixedLane (int direction) {
 	if (trackFixedLane >= laneCount) {
 		trackFixedLane = 0;
 	}
-	outputMessage(format(translate("Lane {}"), trackFixedLane + 1));
+	const char* laneName = (char*)GetSetMediaTrackInfo(track, format("P_LANENAME:{}", trackFixedLane).c_str(), nullptr);
+	if(!laneName) {
+		laneName = "";
+	}
+	outputMessage(format(translate("Lane {} {}"), trackFixedLane + 1, laneName));
 }
 
 void cmdNextLane(Command* cmd) {


### PR DESCRIPTION
This is just a first attempt at supporting the new fixed lanes feature in Reaper 7. It works similar to envelopes in that after focusing a track you can use OSARA: next/previous lane actions to cycle through the fixed lanes on the track. this restricts item navigation to the items on the selected lane.

For better support we would need Cockos to make some additions to the API:

* to get/set the name of a lane
* to tell if a lane is a comp lane and if comping is enabled
* ability to show lane context menus
* In general it would just be nice if lanes were better supported by reaper actions so that they can be selected, pasted on to etc.

From what I can tell a comp area is just an item on a comp lane. After selecting one the actions to move comp area up/down work.

This is just a draft as I am sure there are bugs and it is far from complete.