### PR TITLE
Optionally configure REAPER for optimal screen reader accessibility.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -883,6 +883,7 @@ This list is worth referencing when making your own key map additions, assigning
 - OSARA: Toggle Report time movement during playback/recording
 - OSARA: Toggle Report track numbers
 - OSARA: Toggle Report transport state (play, record, etc.)
+- OSARA: Configure REAPER for optimal screen reader accessibility
 
 ### Muting OSARA Messages in Custom/Cycle Actions
 The action "OSARA: Mute next message from OSARA" can be used in custom/cycle actions to mute OSARA feedback for the next action.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -228,6 +228,7 @@ void cmdConfigReaperOptimal(Command* command) {
 		<< nl << translate_ctxt("optimal REAPER configuration", "Enables legacy file browse dialogs so that REAPER specific options in the Open and Save As dialogs can be reached with the tab key.")
 		<< nl << translate_ctxt("optimal REAPER configuration", "Enables the space key to be used for check boxes, etc. in various windows.")
 		<< nl << translate_ctxt("optimal REAPER configuration", "Shows text to indicate parallel, offline and bypassed in the FX list.")
+		<< nl << translate_ctxt("optimal REAPER configuration", "Uses a standard, accessible edit control for the video code editor.")
 		<< nl;
 	if (MessageBox(
 		GetForegroundWindow(),
@@ -238,12 +239,24 @@ void cmdConfigReaperOptimal(Command* command) {
 		return;
 	}
 	const ReaperSetting settings[] = {
+		// Some of these settings are bit arrays. We just overwrite with the value
+		// which would be set if the setting we need were changed in a clean
+		// configuration. This isn't perfect because it might overwrite other settings
+		// in the same bit array, but the alternative is a lot messier and it
+		// probably doesn't matter too much for our purposes. Nevertheless, we try to
+		// document the correct bit flags below in case we need to change the
+		// approach.
 		{"reaper_explorer", "docked", "0"},
 		{"REAPER", "legacy_filebrowse", "1"},
 		// Allow space key to be used for navigation in various windows
+		// Flag is 1 << 7
 		{"REAPER", "mousewheelmode", "130"},
 		// Show FX state as accessible text in name
+		// Flag is 1 << 20
 		{"REAPER", "fxfloat_focus", "1048579"},
+		// Use standard edit control for video code editor (for accessibility, lacks many features)
+		// Flag is 1 << 11
+		{"REAPER", "video_colorspace", "789507"},
 	};
 	for (const auto& setting: settings) {
 		if (!WritePrivateProfileString(setting.section, setting.key, setting.value,

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
  * OSARA: Open Source Accessibility for the REAPER Application
  * Configuration header
  * Author: James Teh <jamie@jantrid.net>
- * Copyright 2022-2023 James Teh
+ * Copyright 2022-2024 James Teh
  * License: GNU General Public License version 2.0
  */
 
@@ -24,3 +24,5 @@ void loadConfig();
 void cmdConfig(Command* command);
 void registerSettingCommands();
 bool handleSettingCommand(int command);
+void cmdConfigReaperOptimal(Command* command);
+void maybeAutoConfigReaperOptimal();

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2,7 +2,7 @@
  * OSARA: Open Source Accessibility for the REAPER Application
  * Main plug-in code
  * Author: James Teh <jamie@jantrid.net>
- * Copyright 2014-2023 NV Access Limited, James Teh
+ * Copyright 2014-2024 NV Access Limited, James Teh
  * License: GNU General Public License version 2.0
  */
 
@@ -4597,6 +4597,7 @@ Command COMMANDS[] = {
 	{ MAIN_SECTION, {DEFACCEL, _t("OSARA: Select from cursor to end of project")}, "OSARA_SELFROMCURSORTOEND", cmdSelectFromCursorToEndOfProject},
 	{ MAIN_SECTION, {DEFACCEL, _t("OSARA: Set phase normal for all tracks")}, "OSARA_SETPHASENORMALALLTRACKS", cmdSetPhaseNormalAllTracks},
 	{ MAIN_SECTION, {DEFACCEL, _t("OSARA: Unmonitor all tracks")}, "OSARA_UNMONITORALLTRACKS", cmdUnmonitorAllTracks},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Configure REAPER for optimal screen reader accessibility")}, "OSARA_CONFIGREAPEROPTIMAL", cmdConfigReaperOptimal},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current chord/note")}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to next chord")}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to previous chord")}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},
@@ -4871,6 +4872,7 @@ void CALLBACK delayedInit(HWND hwnd, UINT msg, UINT_PTR event, DWORD time) {
 		if (cmd)
 			postCommandsMap.insert(make_pair(cmd, POST_CUSTOM_COMMANDS[i].execute));
 	}
+	maybeAutoConfigReaperOptimal();
 	KillTimer(NULL, event);
 }
 


### PR DESCRIPTION
The user will be prompted once at startup to do this. Alternatively, they can run the action OSARA: Configure REAPER for optimal screen reader accessibility at any time. This currently does the following:

- Undocks the Media Explorer by default so that it gets focus when opened.
- Enables legacy file browse dialogs so that REAPER specific options in the Open and Save As dialogs can be reached with the tab key.
- Enables the space key to be used for check boxes, etc. in various windows.
- Shows text to indicate parallel, offline and bypassed in the FX list.

Fixes #343.