### PR TITLE
Improve contextual reporting for FX: Show/hide track envelope for last touched FX parameter

### DIFF
--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -767,6 +767,6 @@ void cmdToggleLastTouchedEnvelope(Command* command) {
 	if (fakeFocus == FOCUS_ITEM) {
 		cmdhToggleTakeEnvelope(41142); // FX: Show/hide track envelope for last touched FX parameter
 	} else {
-		cmdhToggleTakeEnvelope(41142); // FX: Show/hide track envelope for last touched FX parameter
+		cmdhToggleTrackEnvelope(41142); // FX: Show/hide track envelope for last touched FX parameter
 	}
 }

--- a/src/envelopeCommands.cpp
+++ b/src/envelopeCommands.cpp
@@ -762,3 +762,11 @@ void cmdTogglePreFXPanOrTakePitchEnvelope(Command* command) {
 		cmdhToggleTrackEnvelope(40409); // Track: Toggle track pre-FX pan envelope visible
 	}
 }
+
+void cmdToggleLastTouchedEnvelope(Command* command) {
+	if (fakeFocus == FOCUS_ITEM) {
+		cmdhToggleTakeEnvelope(41142); // FX: Show/hide track envelope for last touched FX parameter
+	} else {
+		cmdhToggleTakeEnvelope(41142); // FX: Show/hide track envelope for last touched FX parameter
+	}
+}

--- a/src/envelopeCommands.h
+++ b/src/envelopeCommands.h
@@ -37,3 +37,4 @@ void cmdToggleVolumeEnvelope(Command* command);
 void cmdTogglePanEnvelope(Command* command);
 void cmdToggleMuteEnvelope(Command* command);
 void cmdTogglePreFXPanOrTakePitchEnvelope(Command* command);
+void cmdToggleLastTouchedEnvelope(Command* command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4518,7 +4518,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40038}, NULL}, NULL, cmdNudgeTimeSelection}, // Time selection: Shift right (by time selection length)
 	{MAIN_SECTION, {{0, 0, 40803}, NULL}, NULL, cmdNudgeTimeSelection}, // Time selection: Swap left edge of time selection to next transient in items
 	{MAIN_SECTION, {{0, 0, 40802}, NULL}, NULL, cmdNudgeTimeSelection}, // Time selection: Extend time selection to next transient in items
-	{MAIN_SECTION, {{0, 0, 41142}, NULL}, NULL, cmdToggleTrackEnvelope}, // FX: Show/hide track envelope for last touched FX parameter
+	{MAIN_SECTION, {{0, 0, 41142}, NULL}, NULL, cmdToggleLastTouchedEnvelope}, // FX: Show/hide track envelope for last touched FX parameter
 	{MAIN_SECTION, {{0, 0, 40406}, NULL}, NULL, cmdToggleTrackEnvelope}, // Track: Toggle track volume envelope visible
 	{MAIN_SECTION, {{0, 0, 40407}, NULL}, NULL, cmdToggleTrackEnvelope}, // Track: Toggle track pan envelope visible
 	{MAIN_SECTION, {{0, 0, 40408}, NULL}, NULL, cmdToggleTrackEnvelope}, // Track: Toggle track pre-FX volume envelope visible


### PR DESCRIPTION
I learned recently that this action has always been contextual, but not clearly named. Its name will be adjusted in the next release of REAPER, already done in daily dev builds. Now OSARA reports whether a track or take envelope has been shown.