### PR TITLE
Add an OSARA sub-menu to the Extensions menu.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -893,6 +893,7 @@ This list is worth referencing when making your own key map additions, assigning
 - OSARA: Toggle Report transport state (play, record, etc.)
 - OSARA: Configure REAPER for optimal screen reader accessibility
 - OSARA: Check for update
+- OSARA: Open online documentation
 
 ### Muting OSARA Messages in Custom/Cycle Actions
 The action "OSARA: Mute next message from OSARA" can be used in custom/cycle actions to mute OSARA feedback for the next action.

--- a/src/osara.h
+++ b/src/osara.h
@@ -211,6 +211,7 @@
 #define REAPERAPI_WANT_LocalizeString
 #define REAPERAPI_WANT_TakeFX_GetNamedConfigParm
 #define REAPERAPI_WANT_GetTrackSendName
+#define REAPERAPI_WANT_AddExtensionsMainMenu
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
This sub-menu contains three options: Online documentation, Check for update and About OSARA. Online documentation simply opens the OSARA website. To facilitate this, the action OSARA: Open online documentation has been added.

@ScottChesworth, let me know if there are any changes you'd like here.