### PR TITLE
Add API function osara_getVersion so that scripts and other extensions can get the running version of OSARA.

### DIFF
--- a/src/exports.cpp
+++ b/src/exports.cpp
@@ -7,6 +7,9 @@
  * License: GNU General Public License version 2.0
  */
 
+// Microsoft wants strncpy_s, but Mac doesn't have it.
+#define _CRT_SECURE_NO_WARNINGS
+#include "buildVersion.h"
 #include "osara.h"
 
 // The _vararg_ version is needed for ReaScript.
@@ -23,6 +26,14 @@ bool osara_isShortcutHelpEnabled() {
 	return isShortcutHelpEnabled;
 }
 
+void osara_getVersion(char* versionOut, int versionOut_sz) {
+	strncpy(versionOut, OSARA_VERSION, versionOut_sz);
+}
+void* _vararg_osara_getVersion(void** args, int nArgs) {
+	osara_getVersion((char*)args[0], (uintptr_t)args[1]);
+	return nullptr;
+}
+
 void registerExports(reaper_plugin_info_t* rec) {
 	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
 	rec->Register("APIvararg_osara_outputMessage",
@@ -35,4 +46,12 @@ void registerExports(reaper_plugin_info_t* rec) {
 		"focus such as list boxes and trees.");
 	rec->Register("API_osara_isShortcutHelpEnabled",
 		(void*)osara_isShortcutHelpEnabled);
+	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
+	rec->Register("APIvararg_osara_getVersion",
+		(void*)_vararg_osara_getVersion);
+	rec->Register("APIdef_osara_getVersion",
+		(void*)"void\0char*,int\0versionOut,versionOut_sz\0"
+		"Get the version of OSARA.\n"
+		"This will be in the form: year.month.day.build,commit\n"
+		"For example: 2024.3.6.1332,13560ef7");
 }


### PR DESCRIPTION
Fixes #765.