### PR TITLE
Downgrade NSIS installer to 2.46 to hopefully reduce anti-virus false positives. (#387)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,9 @@ install:
      }
  - git submodule update --init --depth 1
  - sh: sudo xcode-select -s /Applications/Xcode-13.2.1.app
+ # Use NSIS v2.46 to reduce AV false positives. Borrowed from SWS.
+ - cmd: '"%ProgramFiles(x86)%\NSIS\uninst-nsis.exe" /S'
+ - cmd: choco install -y nsis-unicode
 
 build_script:
  - ps: |

--- a/installer/osara.nsi
+++ b/installer/osara.nsi
@@ -10,7 +10,9 @@
 !include "nsDialogs.nsh"
 
 SetCompressor /SOLID LZMA
-Unicode true
+!ifndef NSIS_UNICODE
+	Unicode true
+!endif
 Name "OSARA"
 Caption "OSARA ${VERSION} Setup"
 OutFile "${OUTFILE}"

--- a/sconstruct
+++ b/sconstruct
@@ -36,15 +36,23 @@ if env["PLATFORM"] == "win32":
 		import winreg
 	except ImportError:
 		import _winreg as winreg
-	# Get the path to makensis.
-	try:
-		with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NSIS",
-				0, winreg.KEY_READ | winreg.KEY_WOW64_32KEY) as nsisKey:
-			makensis = os.path.join(winreg.QueryValueEx(nsisKey, None)[0], "makensis.exe")
-	except WindowsError:
-		makensis = "makensis"
+	def getMakensis():
+		"""Get the path to makensis."""
+		try:
+			with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NSIS\Unicode",
+					0, winreg.KEY_READ | winreg.KEY_WOW64_32KEY) as nsisKey:
+				return os.path.join(winreg.QueryValueEx(nsisKey, None)[0], "makensis.exe")
+		except WindowsError:
+			pass
+		try:
+			with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\NSIS",
+					0, winreg.KEY_READ | winreg.KEY_WOW64_32KEY) as nsisKey:
+				return os.path.join(winreg.QueryValueEx(nsisKey, None)[0], "makensis.exe")
+		except WindowsError:
+			pass
+		return "makensis.exe"
 	installer = env.Command("installer/osara_${version}.exe", ["installer/osara.nsi", "build"],
-		[[makensis, "/V2",
+		[[getMakensis(), "/V2",
 		"/DVERSION=$version", '/DPUBLISHER="$publisher"','/DCOPYRIGHT="$copyright"',
 		"/DOUTFILE=${TARGET.abspath}",
 		"$SOURCE"]])


### PR DESCRIPTION
I got this idea from SWS: https://github.com/reaper-oss/sws/commit/21a5332a85edbe3b87c2de8c9f2af124f4b6af9c