### PR TITLE
Disable the Windows specific OSARA hack to report active/bypass in the FX chain list in REAPER 7.06 and later, since REAPER now makes this accessible properly.

### DIFF
--- a/src/fxChain.cpp
+++ b/src/fxChain.cpp
@@ -176,6 +176,11 @@ bool maybeSwitchToFxPluginWindow() {
 // If the FX list in an FX chain dialog is focused, report active/bypassed for
 // the selected effect.
 bool maybeReportFxChainBypass(bool aboutToToggle) {
+	string version = string(GetAppVersion(), 0, 4);
+	if (stod(version) >= 7.06) {
+		// REAPER >= 7.06 made this properly accessible.
+		return false;
+	}
 	if (!isFxListFocused()) {
 		return false;
 	}

--- a/src/osara.h
+++ b/src/osara.h
@@ -212,6 +212,7 @@
 #define REAPERAPI_WANT_TakeFX_GetNamedConfigParm
 #define REAPERAPI_WANT_GetTrackSendName
 #define REAPERAPI_WANT_AddExtensionsMainMenu
+#define REAPERAPI_WANT_GetAppVersion
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 


### PR DESCRIPTION
Fixes #1016.
I haven't actually tested this on REAPER 7.05 or earlier to check whether the hack still works there. If someone gets a chance before I do, that'd be awesome.