### PR TITLE
Track Parameters dialog: For send/receive/hardware output parameters, add an option in the context menu to delete the send/receive/hardware output.

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -212,6 +212,7 @@
 #define REAPERAPI_WANT_GetTrackSendName
 #define REAPERAPI_WANT_AddExtensionsMainMenu
 #define REAPERAPI_WANT_GetAppVersion
+#define REAPERAPI_WANT_RemoveTrackSend
 #include <reaper/reaper_plugin.h>
 #include <reaper/reaper_plugin_functions.h>
 

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -77,6 +77,10 @@ class ParamSource {
 	virtual int getParamCount() = 0;
 	virtual string getParamName(int param) = 0;
 	virtual unique_ptr<Param> getParam(int param) = 0;
+
+	// Called to rebuild the parameter list because one or more parameters were
+	// invalidated. This need only be implemented if the source doesn't
+	// dynamically fetch parameter info when the getParam* methods are called.
 	virtual void rebuildParams() {}
 };
 


### PR DESCRIPTION
Because removing a send obviously removes its parameters, this involved teaching the Parameters UI code how to fully rebuild the parameter list due to a parameter being invalidated.

CC @ranetto.