### PR TITLE
Switch actions for moving to start and end of items

### DIFF
--- a/config/mac/reaper-kb.ini
+++ b/config/mac/reaper-kb.ini
@@ -131,10 +131,6 @@ KEY 1 66 40298 0		 # Main : B : Track: Toggle FX bypass for current/last touched
 KEY 41 88 40307 0		 # Main : Cmd+Control+X : Item: Cut selected area of items
 KEY 41 46 40312 0		 # Main : Cmd+Control+NumPad Delete : Item: Remove selected area of items
 KEY 32 96 40315 0		 # Main : Control+` : Item: Auto trim/split items (remove silence)...
-KEY 8 60 40318 0		 # Main : Cmd+< : OVERRIDE DEFAULT : Item navigation: Move cursor left to edge of item
-KEY 9 103 40318 0		 # Main : Cmd+NumPad 7 : Item navigation: Move cursor left to edge of item
-KEY 8 62 40319 0		 # Main : Cmd+> : OVERRIDE DEFAULT : Item navigation: Move cursor right to edge of item
-KEY 9 105 40319 0		 # Main : Cmd+NumPad 9 : Item navigation: Move cursor right to edge of item
 KEY 16 91 40320 0		 # Main : Opt+[ : Time selection: Nudge left edge left
 KEY 16 93 40321 0		 # Main : Opt+] : Time selection: Nudge left edge right
 KEY 8 91 40322 0		 # Main : Cmd+[ : OVERRIDE DEFAULT : Time selection: Nudge right edge left
@@ -250,10 +246,14 @@ KEY 21 85 41049 0		 # Main : Opt+Shift+U : Insert new subproject...
 KEY 1 86 41051 0		 # Main : V : OVERRIDE DEFAULT : Item properties: Toggle take reverse
 KEY 16 61 41129 0		 # Main : Opt+= : Tempo: Increase current project tempo 01 BPM
 KEY 16 45 41130 0		 # Main : Opt+- : Tempo: Decrease current project tempo 01 BPM
-KEY 25 76 41142 0		 # Main : Cmd+Opt+L : OVERRIDE DEFAULT : FX: Show/hide track envelope for last touched FX parameter
+KEY 25 76 41142 0		 # Main : Cmd+Opt+L : OVERRIDE DEFAULT : FX: Show/hide track/take envelope for last touched FX parameter
 KEY 13 72 41150 0		 # Main : Cmd+Shift+H : Envelope: Hide all envelopes for all tracks
 KEY 5 87 41160 0		 # Main : Shift+W : OVERRIDE DEFAULT : Automation: Write current values for all writing envelopes to time selection
 KEY 33 87 41162 0		 # Main : Control+W : Automation: Write current values for all writing envelopes from cursor to end of project
+KEY 8 60 41173 0		 # Main : Cmd+< : OVERRIDE DEFAULT : Item navigation: Move cursor to start of items
+KEY 9 103 41173 0		 # Main : Cmd+NumPad 7 : Item navigation: Move cursor to start of items
+KEY 8 62 41174 0		 # Main : Cmd+> : OVERRIDE DEFAULT : Item navigation: Move cursor to end of items
+KEY 9 105 41174 0		 # Main : Cmd+NumPad 9 : Item navigation: Move cursor to end of items
 KEY 0 47 41187 0		 # Main : / : Scrub: Toggle looped-segment scrub at edit cursor
 KEY 41 117 41199 0		 # Main : Cmd+Control+F6 : Track: Toggle track solo defeat
 KEY 25 70 41206 0		 # Main : Cmd+Opt+F : OVERRIDE DEFAULT : Item: Move and stretch items to fit time selection

--- a/config/windows/reaper-kb.ini
+++ b/config/windows/reaper-kb.ini
@@ -136,9 +136,7 @@ KEY 1 66 40298 0		 # Main : B : Track: Toggle FX bypass for current/last touched
 KEY 41 88 40307 0		 # Main : Ctrl+Win+X : Item: Cut selected area of items
 KEY 41 32814 40312 0		 # Main : Ctrl+Win+DELETE : Item: Remove selected area of items
 KEY 9 192 40315 0		 # Main : Ctrl+' : Item: Auto trim/split items (remove silence)...
-KEY 13 188 40318 0		 # Main : Ctrl+Shift+, : Item navigation: Move cursor left to edge of item
 KEY 9 103 40318 0		 # Main : Ctrl+NUM 7 : Item navigation: Move cursor left to edge of item
-KEY 13 190 40319 0		 # Main : Ctrl+Shift+. : Item navigation: Move cursor right to edge of item
 KEY 9 105 40319 0		 # Main : Ctrl+NUM 9 : Item navigation: Move cursor right to edge of item
 KEY 9 219 40320 0		 # Main : Ctrl+[ : OVERRIDE DEFAULT : Time selection: Nudge left edge left
 KEY 9 221 40321 0		 # Main : Ctrl+] : OVERRIDE DEFAULT : Time selection: Nudge left edge right
@@ -238,10 +236,12 @@ KEY 21 85 41049 0		 # Main : Alt+Shift+U : Insert new subproject...
 KEY 1 86 41051 0		 # Main : V : OVERRIDE DEFAULT : Item properties: Toggle take reverse
 KEY 17 187 41129 0		 # Main : Alt+= : Tempo: Increase current project tempo 01 BPM
 KEY 17 189 41130 0		 # Main : Alt+- : Tempo: Decrease current project tempo 01 BPM
-KEY 25 76 41142 0		 # Main : Ctrl+Alt+L : OVERRIDE DEFAULT : FX: Show/hide track envelope for last touched FX parameter
+KEY 25 76 41142 0		 # Main : Ctrl+Alt+L : OVERRIDE DEFAULT : FX: Show/hide track/take envelope for last touched FX parameter
 KEY 13 72 41150 0		 # Main : Ctrl+Shift+H : Envelope: Hide all envelopes for all tracks
 KEY 5 87 41160 0		 # Main : Shift+W : OVERRIDE DEFAULT : Automation: Write current values for all writing envelopes to time selection
 KEY 9 87 41162 0		 # Main : Ctrl+W : Automation: Write current values for all writing envelopes from cursor to end of project
+KEY 13 188 41173 0		 # Main : Ctrl+Shift+, : Item navigation: Move cursor to start of items
+KEY 13 190 41174 0		 # Main : Ctrl+Shift+. : Item navigation: Move cursor to end of items
 KEY 1 191 41187 0		 # Main : / : Scrub: Toggle looped-segment scrub at edit cursor
 KEY 41 117 41199 0		 # Main : Ctrl+Win+F6 : Track: Toggle track solo defeat
 KEY 25 70 41206 0		 # Main : Ctrl+Alt+F : OVERRIDE DEFAULT : Item: Move and stretch items to fit time selection

--- a/readme.md
+++ b/readme.md
@@ -142,8 +142,8 @@ Most of these are actions built into REAPER, but a few are useful actions from t
 - Item edit: Grow right edge of items: Alt+. or Alt+NumPad6
 - Item: go to next stretch marker: Control+'
 - Item: go to previous stretch marker: Control+;
-- Item navigation: Move cursor left to edge of item: Control+Shift+,
-- Item navigation: Move cursor right to edge of item: Control+Shift+.
+- Item navigation: Move cursor to start of items: Control+Shift+,
+- Item navigation: Move cursor to end of items: Control+Shift+.
 - Item: Select all items in track: Control+Alt+A
 - Item: Select all items on selected tracks in current time selection: Alt+Shift+A
 - Item grouping: Group items: Control+G


### PR DESCRIPTION
Switched to a pair of REAPER actions which have behaviour that's more suitable for moving to the start and end of contiguous and non-contiguous item selections.