### PR TITLE
Report source type in item navigation

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3157,6 +3157,13 @@ void cmdGoToMasterTrack(Command* command){
 	postGoToTrack(0);
 }
 
+string getReportableSourceType(const char* type) {
+	if((!type)||(!*type)) return "";
+	string reported_type=type;
+	if((reported_type=="VIDEO")||(reported_type=="MIDI")) return reported_type;
+	return "AUDIO";
+}
+
 void moveToItem(int direction, bool clearSelection=true, bool select=true) {
 	unsigned int undoMask = getConfigUndoMask();
 	bool makeUndoPoint = undoMask&1;
@@ -3236,6 +3243,9 @@ void moveToItem(int direction, bool clearSelection=true, bool select=true) {
 		}
 		MediaItem_Take* take = GetActiveTake(item);
 		if (take) {
+			if (auto* source = (PCM_source*)GetSetMediaItemTakeInfo(take, "P_SOURCE", nullptr)) {
+				s << " " << getReportableSourceType(source->GetType());
+			}
 			s << " " << GetTakeName(take);
 		}
 		int takeCount = CountTakes(item);


### PR DESCRIPTION
When navigating through items, the source type (audio, video, midi) is announced when reporting take information (see issue #1066).

In short, "AUDIO" is reported by default for anything that isn't tagged as "VIDEO" or "MIDI". Basic tests show this to be working nicely:
Wav, MP3 and FLAC files report "AUDIO", as do frozen MIDI items which seem to have additional content announced naturally to suggest that it is a frozen MIDI item.
Giff files specify "VIDEO".
MIDI reports MIDI, as expected.

The one thing I haven't tested are container files like MP4 or ogg, or other video formats that inherently support embedded audio (simply because I have none to test with).

Hopefully I've nailed the formatting for this one.
