### PR TITLE
Inform users if ripple is enabled when they cut or delete items

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1510,6 +1510,16 @@ void postCycleRippleMode(int command) {
 	}
 }
 
+string getRippleMode(int command) {
+	if (GetToggleCommandState(40310)) {
+		return translate("ripple per-track");
+	} else if (GetToggleCommandState(40311)) {
+		return translate("ripple all tracks");
+	} else {
+		return translate("ripple off");
+	}
+}
+
 void reportRepeat(bool repeat) {
 	outputMessage(repeat ?
 		translate("repeat on") :
@@ -3510,11 +3520,9 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 					count = countAffected(GetSelectedMediaItem, selItems);
 				}
 				if(GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
-				// Translators: used for  "Item: Cut selected area of items" and "Item:
-				// Remove selected area of items" when ripple is enabled.
-				// {} is replaced by the number of items affected.
+				// Inform users that a ripple mode is enabled.
 				outputMessage(format(
-					translate_plural("selected area of {} item removed with ripple enabled", "selected area of {} items removed with ripple enabled", count), count));
+					translate_plural("selected area of {} item removed, " + getRippleMode(command->gaccel.accel.cmd), "selected area of {} items removed, " + getRippleMode(command->gaccel.accel.cmd), count), count));
 				} else {
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
@@ -3534,10 +3542,9 @@ void cmdhRemoveItems(int command) {
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
 	if (GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
-		// Translators: Reported when items are removed and ripple is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple enabled".
+		// Inform users that a ripple mode is active because that can influence the resulting positions of items on their timeline.
 		outputMessage(format(
-			translate_plural("{} item removed with ripple enabled", "{} items removed with ripple enabled", removed),
+			translate_plural("{} item removed, " + getRippleMode(command), "{} items removed, " + getRippleMode(command), removed),
 			removed));
 	} else {
 		// Translators: Reported when items are removed. {} will be replaced with the

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3506,14 +3506,23 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 				int count = 0;
 				if(selItems == 0) { // these commands treat no item selection as if all items are selected
 					count = countAffected(GetMediaItem, CountMediaItems(nullptr));
-				} else {
+				} else if (selItems > 0) {
 					count = countAffected(GetSelectedMediaItem, selItems);
 				}
+				if(GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
+				// Translators: used for  "Item: Cut selected area of items" and "Item:
+				// Remove selected area of items" when ripple is enabled.
+				// {} is replaced by the number of items affected.
+				outputMessage(format(
+					translate_plural("selected area of {} item removed with ripple enabled", "selected area of {} items removed with ripple enabled", count), count));
+				} else {
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
 				// affected.
 				outputMessage(format(
 					translate_plural("selected area of {} item removed", "selected area of {} items removed", count), count));
+				}
+				break;
 			}
 		}
 	}

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3512,20 +3512,20 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 				break;
 			}
 			default: {
-				ostringstream s;
 				int count = 0;
 				if(selItems == 0) { // these commands treat no item selection as if all items are selected
 					count = countAffected(GetMediaItem, CountMediaItems(nullptr));
 				} else {
 					count = countAffected(GetSelectedMediaItem, selItems);
 				}
+				ostringstream s;
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
 				// affected.
 				s << format(
 					translate_plural("selected area of {} item removed", "selected area of {} items removed", count), count);
 				maybeAddRippleMessage(s, command->gaccel.accel.cmd);
-				outputMessage(s.str());
+				outputMessage(s);
 			}
 		}
 	}
@@ -3543,7 +3543,7 @@ void cmdhRemoveItems(int command) {
 		translate_plural("{} item removed", "{} items removed", removed),
 		removed);
 	maybeAddRippleMessage(s, command);
-	outputMessage(s.str());
+	outputMessage(s);
 }
 
 void cmdRemoveItems(Command* command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3524,11 +3524,17 @@ void cmdhRemoveItems(int command) {
 	int oldCount = CountMediaItems(0);
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
-	if (GetToggleCommandState(40310 || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
-		// Translators: Reported when items are removed and ripple is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple enabled".
+	if (GetToggleCommandState(40310)) { // Set ripple editing per-track
+		// Translators: Reported when items are removed and ripple per track is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple per track enabled".
 		outputMessage(format(
-			translate_plural("{} item removed with ripple enabled", "{} items removed with ripple enabled", removed),
+			translate_plural("{} item removed with ripple per track enabled", "{} items removed with ripple per track enabled", removed),
+			removed));
+	} else if (GetToggleCommandState(40311)) { // Set ripple editing all tracks
+		// Translators: Reported when items are removed and ripple all tracks is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple all enabled".
+		outputMessage(format(
+			translate_plural("{} item removed with ripple all enabled", "{} items removed with ripple all enabled", removed),
 			removed));
 	} else {
 		// Translators: Reported when items are removed. {} will be replaced with the

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3524,17 +3524,11 @@ void cmdhRemoveItems(int command) {
 	int oldCount = CountMediaItems(0);
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
-	if (GetToggleCommandState(40310)) { // Set ripple editing per-track
-		// Translators: Reported when items are removed and ripple per track is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple per track enabled".
+	if (GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
+		// Translators: Reported when items are removed and ripple is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple enabled".
 		outputMessage(format(
-			translate_plural("{} item removed with ripple per track enabled", "{} items removed with ripple per track enabled", removed),
-			removed));
-	} else if (GetToggleCommandState(40311)) { // Set ripple editing all tracks
-		// Translators: Reported when items are removed and ripple all tracks is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple all enabled".
-		outputMessage(format(
-			translate_plural("{} item removed with ripple all enabled", "{} items removed with ripple all enabled", removed),
+			translate_plural("{} item removed with ripple enabled", "{} items removed with ripple enabled", removed),
 			removed));
 	} else {
 		// Translators: Reported when items are removed. {} will be replaced with the

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3524,11 +3524,25 @@ void cmdhRemoveItems(int command) {
 	int oldCount = CountMediaItems(0);
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
-	// Translators: Reported when items are removed. {} will be replaced with the
-	// number of items; e.g. "2 items removed".
-	outputMessage(format(
-		translate_plural("{} item removed", "{} items removed", removed),
-		removed));
+	if (GetToggleCommandState(40310)) { // Set ripple editing per-track
+		// Translators: Reported when items are removed and ripple per track is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple per track enabled".
+		outputMessage(format(
+			translate_plural("{} item removed with ripple per track enabled", "{} items removed with ripple per track enabled", removed),
+			removed));
+	} else if (GetToggleCommandState(40311)) { // Set ripple editing all tracks
+		// Translators: Reported when items are removed and ripple all tracks is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple all enabled".
+		outputMessage(format(
+			translate_plural("{} item removed with ripple all enabled", "{} items removed with ripple all enabled", removed),
+			removed));
+	} else {
+		// Translators: Reported when items are removed. {} will be replaced with the
+		// number of items; e.g. "2 items removed".
+		outputMessage(format(
+			translate_plural("{} item removed", "{} items removed", removed),
+			removed));
+	}
 }
 
 void cmdRemoveItems(Command* command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3524,17 +3524,11 @@ void cmdhRemoveItems(int command) {
 	int oldCount = CountMediaItems(0);
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
-	if (GetToggleCommandState(40310)) { // Set ripple editing per-track
-		// Translators: Reported when items are removed and ripple per track is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple per track enabled".
+	if (GetToggleCommandState(40310 || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
+		// Translators: Reported when items are removed and ripple is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
+		// {} will be replaced with the number of items; e.g. "2 items removed with ripple enabled".
 		outputMessage(format(
-			translate_plural("{} item removed with ripple per track enabled", "{} items removed with ripple per track enabled", removed),
-			removed));
-	} else if (GetToggleCommandState(40311)) { // Set ripple editing all tracks
-		// Translators: Reported when items are removed and ripple all tracks is enabled. We inform users that ripple is on because that can influence the resulting positions of items on their timeline.
-		// {} will be replaced with the number of items; e.g. "2 items removed with ripple all enabled".
-		outputMessage(format(
-			translate_plural("{} item removed with ripple all enabled", "{} items removed with ripple all enabled", removed),
+			translate_plural("{} item removed with ripple enabled", "{} items removed with ripple enabled", removed),
 			removed));
 	} else {
 		// Translators: Reported when items are removed. {} will be replaced with the

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1511,10 +1511,11 @@ void postCycleRippleMode(int command) {
 }
 
 void maybeAddRippleMessage(ostringstream& s, int command) {
-	if (GetToggleCommandState(40310) || GetToggleCommandState(40311)) // if either ripple mode is enabled
+	if (GetToggleCommandState(40310) || GetToggleCommandState(40311)) {
 		// Translators: This message will be appended when removing or pasting items with ripple per-track or ripple all tracks enabled; E.G.
 		// "2 items removed ripple is on".
 		s << " " << translate("ripple is on");
+	}
 }
 
 void reportRepeat(bool repeat) {
@@ -3420,6 +3421,7 @@ void cmdPaste(Command* command) {
 	if (s.tellp() > 0) {
 		// Translators: Reported after the number of tracks and/or items added.
 		s << " " << translate("added");
+		maybeAddRippleMessage(s, command->gaccel.accel.cmd);
 		outputMessage(s);
 		return;
 	}
@@ -3500,34 +3502,30 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 			case 40014: { // Item: Copy loop of selected area of audio items
 				if(selItems == 0) {
 					outputMessage(translate("no items selected"));
-				} else {
-					int count = countAffected(GetSelectedMediaItem, selItems);
-					// Translators: used for "Item: Copy selected area of items".
-					// {} is replaced by the number of items affected.
-					outputMessage(format(
-						translate_plural("selected area of {} item copied", "selected area of {} items copied", count), count));
+					break;
 				}
+				int count = countAffected(GetSelectedMediaItem, selItems);
+				// Translators: used for  "Item: Copy selected area of items".
+				// {} is replaced by the number of items affected.
+				outputMessage(format(
+					translate_plural("selected area of {} item copied", "selected area of {} items copied", count), count));
 				break;
 			}
 			default: {
+				ostringstream s;
 				int count = 0;
 				if(selItems == 0) { // these commands treat no item selection as if all items are selected
 					count = countAffected(GetMediaItem, CountMediaItems(nullptr));
-				} else if (selItems > 0) {
+				} else {
 					count = countAffected(GetSelectedMediaItem, selItems);
 				}
-				ostringstream s;
-				if (count == 1) {
-					s << format(translate("selected area of {} item removed"), count);
-				} else {
-					// Translators: used for "Item: Cut selected area of items" and "Item:
-					// Remove selected area of items". {} is replaced by the number of items
-					// affected.
-					s << format(translate("selected area of {} items removed"), count);
-				}
+				// Translators: used for  "Item: Cut selected area of items" and "Item:
+				// Remove selected area of items".  {} is replaced by the number of items
+				// affected.
+				s << format(
+					translate_plural("selected area of {} item removed", "selected area of {} items removed", count), count);
 				maybeAddRippleMessage(s, command->gaccel.accel.cmd);
 				outputMessage(s.str());
-				break;
 			}
 		}
 	}
@@ -3539,14 +3537,11 @@ void cmdhRemoveItems(int command) {
 	Main_OnCommand(command, 0);
 	int removed = oldCount - CountMediaItems(0);
 	ostringstream s;
-	if (removed == 1) {
-		// Translators: Reported when one item is removed.
-		s << format(translate("{} item removed"), removed);
-	} else {
-		// Translators: Reported when multiple items are removed. {} will be replaced with the
-		// number of items; e.g. "2 items removed".
-		s << format(translate("{} items removed"), removed);
-	}
+	// Translators: Reported when items are removed. {} will be replaced with the
+	// number of items; e.g. "2 items removed".
+	s << format(
+		translate_plural("{} item removed", "{} items removed", removed),
+		removed);
 	maybeAddRippleMessage(s, command);
 	outputMessage(s.str());
 }

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1510,7 +1510,7 @@ void postCycleRippleMode(int command) {
 	}
 }
 
-string getRippleMode(int command) {
+string maybeAddRippleMessage(int command) {
 	if (GetToggleCommandState(40310)) {
 		return translate("ripple per-track");
 	} else if (GetToggleCommandState(40311)) {
@@ -3522,7 +3522,7 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 				if(GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
 				// Inform users that a ripple mode is enabled.
 				outputMessage(format(
-					translate_plural("selected area of {} item removed, " + getRippleMode(command->gaccel.accel.cmd), "selected area of {} items removed, " + getRippleMode(command->gaccel.accel.cmd), count), count));
+					translate_plural("selected area of {} item removed, " + maybeAddRippleMessage(command->gaccel.accel.cmd), "selected area of {} items removed, " + maybeAddRippleMessage(command->gaccel.accel.cmd), count), count));
 				} else {
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
@@ -3544,7 +3544,7 @@ void cmdhRemoveItems(int command) {
 	if (GetToggleCommandState(40310) || GetToggleCommandState(40311)) { // Set ripple editing per-track or Set ripple editing all tracks
 		// Inform users that a ripple mode is active because that can influence the resulting positions of items on their timeline.
 		outputMessage(format(
-			translate_plural("{} item removed, " + getRippleMode(command), "{} items removed, " + getRippleMode(command), removed),
+			translate_plural("{} item removed, " + maybeAddRippleMessage(command), "{} items removed, " + maybeAddRippleMessage(command), removed),
 			removed));
 	} else {
 		// Translators: Reported when items are removed. {} will be replaced with the


### PR DESCRIPTION
Scenarios where hearing some sort of reminder that ripple is enabled would've been helpful appear on my radar often, especially when teaching newcomers. Not knowing this information has also tripped up a more experienced user on RWP recently.
Please try removing items with each ripple mode, tell me whether the additional feedback is useful. Paging @ptorpey as I know he's interested in this.