### PR TITLE
Improve selection inserting notes. Closes #1091

### DIFF
--- a/config/mac/reaper-kb.ini
+++ b/config/mac/reaper-kb.ini
@@ -13,6 +13,8 @@ ACT 1 0 "e85f8b38153399499e2e176a8bcec06c" "Custom: trim left edge of items resp
 ACT 1 0 "0e77201d60c10d4d844fe05ac22623e1" "Custom: trim right edge of items respecting ripple" 40512 41311
 ACT 1 32060 "75564b5383268f4e8701b2465bb5e198" "Custom: Go to next midi item" 40798 40036 _FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR
 ACT 1 32060 "3d82f1008d23dd4c9849c028325d3743" "Custom: Go to previous midi item" 40797 40036 _FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR
+ACT 1 32060 "fa94bfdd2b044634b738a98c96b2f75d" "Custom: Insert note, advancing edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 _OSARA_ME_MUTENEXTMESSAGE 40214 40051
+ACT 1 32060 "720c5c7f27504a868a0360b323eca963" "Custom: Insert note, maintaining current position of edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 _OSARA_ME_MUTENEXTMESSAGE 40214 1000
 ACT 1 32060 "53b7b74114d130409a9fd4d31c97ebe4" "Custom: Select and quantize notes position to grid" 40746 40469 40880 40477
 ACT 1 32061 "4a1c1a073e300c4cb987bb7b787bd065" "Custom: Move edit cursor to end of file" 40037 _OSARA_FOCUSMIDIEVENT
 ACT 1 32061 "9752206b806c41488273e8bf51d94c48" "Custom: move edit cursor to start of file" 40036 _OSARA_FOCUSMIDIEVENT
@@ -462,8 +464,6 @@ KEY 29 32808 0 32060		 # MIDI Editor : Cmd+Opt+Shift+Down : DISABLED DEFAULT
 KEY 9 101 0 32060		 # MIDI Editor : Cmd+NumPad 5 : DISABLED DEFAULT
 KEY 9 32 0 32060		 # MIDI Editor : Cmd+Space : DISABLED DEFAULT
 KEY 9 90 0 32060		 # MIDI Editor : Cmd+Z : DISABLED DEFAULT
-KEY 1 101 1000 32060		 # MIDI Editor : NumPad 5 : Edit: Insert note at edit cursor (no advance edit cursor)
-KEY 1 73 1000 32060		 # MIDI Editor : I : OVERRIDE DEFAULT : Edit: Insert note at edit cursor (no advance edit cursor)
 KEY 0 95 1011 32060		 # MIDI Editor : _ : View: Zoom out horizontally
 KEY 9 82 1139 32060		 # MIDI Editor : Cmd+R : Transport: Toggle repeat
 KEY 9 115 2 32060		 # MIDI Editor : Cmd+F4 : File: Close window
@@ -475,8 +475,6 @@ KEY 21 37 40047 32060		 # MIDI Editor : Opt+Shift+NumPad Left : Navigate: Move e
 KEY 21 39 40048 32060		 # MIDI Editor : Opt+Shift+NumPad Right : Navigate: Move edit cursor right by grid
 KEY 17 32806 40049 32060		 # MIDI Editor : Opt+Up : OVERRIDE DEFAULT : Edit: Increase pitch cursor one semitone
 KEY 17 32808 40050 32060		 # MIDI Editor : Opt+Down : OVERRIDE DEFAULT : Edit: Decrease pitch cursor one semitone
-KEY 5 101 40051 32060		 # MIDI Editor : Shift+NumPad 5 : Edit: Insert note at edit cursor
-KEY 5 73 40051 32060		 # MIDI Editor : Shift+I : OVERRIDE DEFAULT : Edit: Insert note at edit cursor
 KEY 1 78 40177 32060		 # MIDI Editor : N : Edit: Move notes up one semitone
 KEY 5 78 40178 32060		 # MIDI Editor : Shift+N : Edit: Move notes down one semitone
 KEY 17 78 40179 32060		 # MIDI Editor : Opt+N : OVERRIDE DEFAULT : Edit: Move notes up one octave
@@ -591,6 +589,8 @@ KEY 9 8 41295 32060		 # MIDI Editor : Cmd+Backspace : Set length for next insert
 KEY 8 46 41712 32060		 # MIDI Editor : Cmd+. : Set length for next inserted note: dotted preserving division length
 KEY 9 84 41713 32060		 # MIDI Editor : Cmd+T : Set length for next inserted note: triplet preserving division length
 KEY 5 81 _53b7b74114d130409a9fd4d31c97ebe4 32060		 # MIDI Editor : Shift+Q : Custom: Select and quantize notes position to grid
+KEY 1 101 _720c5c7f27504a868a0360b323eca963 32060		 # MIDI Editor : NumPad 5 : Custom: Insert note, maintaining current position of edit cursor
+KEY 1 73 _720c5c7f27504a868a0360b323eca963 32060		 # MIDI Editor : I : OVERRIDE DEFAULT : Custom: Insert note, maintaining current position of edit cursor
 KEY 9 70 _FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR 32060		 # MIDI Editor : Cmd+F : SWS/FNG: Select notes nearest edit cursor
 KEY 9 32807 _OSARA_MIDINEXTITEM 32060		 # MIDI Editor : Cmd+Right : OVERRIDE DEFAULT : OSARA: Move to next midi item on track
 KEY 9 32805 _OSARA_MIDIPREVITEM 32060		 # MIDI Editor : Cmd+Left : OVERRIDE DEFAULT : OSARA: Move to previous midi item on track
@@ -608,6 +608,8 @@ KEY 5 32805 _OSARA_PREVCHORDKEEPSEL 32060		 # MIDI Editor : Shift+Left : OVERRID
 KEY 1 32806 _OSARA_PREVNOTE 32060		 # MIDI Editor : Up : OVERRIDE DEFAULT : OSARA: Move to previous note in chord
 KEY 5 32806 _OSARA_PREVNOTEKEEPSEL 32060		 # MIDI Editor : Shift+Up : OVERRIDE DEFAULT : OSARA: Move to previous note in chord and add to selection
 KEY 21 65 _OSARA_SELSAMEPITCHTIMESEL 32060		 # MIDI Editor : Opt+Shift+A : OSARA: Select all notes with the same pitch starting in time selection
+KEY 5 101 _fa94bfdd2b044634b738a98c96b2f75d 32060		 # MIDI Editor : Shift+NumPad 5 : Custom: Insert note, advancing edit cursor
+KEY 5 73 _fa94bfdd2b044634b738a98c96b2f75d 32060		 # MIDI Editor : Shift+I : OVERRIDE DEFAULT : Custom: Insert note, advancing edit cursor
 KEY 0 63 0 32061		 # MIDI Event List Editor : ? : DISABLED DEFAULT
 KEY 9 101 0 32061		 # MIDI Event List Editor : Cmd+NumPad 5 : DISABLED DEFAULT
 KEY 1 101 1000 32061		 # MIDI Event List Editor : NumPad 5 : Edit: Insert note at edit cursor (no advance edit cursor)

--- a/config/windows/reaper-kb.ini
+++ b/config/windows/reaper-kb.ini
@@ -11,8 +11,8 @@ ACT 1 0 "e85f8b38153399499e2e176a8bcec06c" "Custom: trim left edge of items resp
 ACT 1 0 "0e77201d60c10d4d844fe05ac22623e1" "Custom: trim right edge of items respecting ripple" 40512 41311
 ACT 1 32060 "75564b5383268f4e8701b2465bb5e198" "Custom: Go to next midi item" 40798 40036 _FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR
 ACT 1 32060 "3d82f1008d23dd4c9849c028325d3743" "Custom: Go to previous midi item" 40797 40036 _FNG_ME_SELECT_NOTES_NEAR_EDIT_CURSOR
-ACT 1 32060 "c8f4a5404a4e1740bceb836c4d466c93" "Custom: Insert note, advancing edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 40051
-ACT 1 32060 "929bf923a092324385a675281c3f4d4b" "Custom: Insert note, maintaining current position of edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 1000
+ACT 1 32060 "c8f4a5404a4e1740bceb836c4d466c93" "Custom: Insert note, advancing edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 _OSARA_ME_MUTENEXTMESSAGE 40214 40051
+ACT 1 32060 "929bf923a092324385a675281c3f4d4b" "Custom: Insert note, maintaining current position of edit cursor" _OSARA_ME_MUTENEXTMESSAGE 40449 _OSARA_ME_MUTENEXTMESSAGE 40214 1000
 ACT 1 32060 "53b7b74114d130409a9fd4d31c97ebe4" "Custom: Select and quantize notes position to grid" 40746 40469 40880 40477
 ACT 1 32061 "4a1c1a073e300c4cb987bb7b787bd065" "Custom: Move edit cursor to end of file" 40037 _OSARA_FOCUSMIDIEVENT
 ACT 1 32061 "9752206b806c41488273e8bf51d94c48" "Custom: move edit cursor to start of file" 40036 _OSARA_FOCUSMIDIEVENT


### PR DESCRIPTION
This fixes the issue where each time users insert a note using the keyboard, the new note would be added to selection. Now we only select the most recently inserted note instead.