### PR TITLE
Fix reportTempoTimeSig to respect transport state

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3648,9 +3648,17 @@ void reportTempoTimeSig() {
 		return;
 	}
 	double tempo=0;
+	double pos=0;
 	int timesig_num=0;
 	int timesig_denom=0;
-	double pos=GetPlayPosition();
+	int state=GetPlayState();
+	if(state&2) { // paused
+		pos=GetCursorPosition();
+	} else if((state&1)||(state&4)) { // playing or recording
+		pos=GetPlayPosition();
+	} else { // stopped
+		pos=GetCursorPosition();
+	}
 	TimeMap_GetTimeSigAtTime(proj, pos, &timesig_num, &timesig_denom, &tempo);
 	outputMessage(format("{}, {}/{}", formatDouble(tempo, 1, false), timesig_num, timesig_denom));
 }

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3648,17 +3648,10 @@ void reportTempoTimeSig() {
 		return;
 	}
 	double tempo=0;
-	double pos=0;
+	int state=GetPlayState();
+	double pos = state & 1 ? GetPlayPosition() : GetCursorPosition();
 	int timesig_num=0;
 	int timesig_denom=0;
-	int state=GetPlayState();
-	if(state&2) { // paused
-		pos=GetCursorPosition();
-	} else if((state&1)||(state&4)) { // playing or recording
-		pos=GetPlayPosition();
-	} else { // stopped
-		pos=GetCursorPosition();
-	}
 	TimeMap_GetTimeSigAtTime(proj, pos, &timesig_num, &timesig_denom, &tempo);
 	outputMessage(format("{}, {}/{}", formatDouble(tempo, 1, false), timesig_num, timesig_denom));
 }


### PR DESCRIPTION
Now uses the play position when playing/recording, and cursor position when stopped/paused.

In response to issue #1095.
