### PR TITLE
Provide information about nearby markers and regions in OSARA: Report edit/play cursor position and transport state.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -776,7 +776,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Select from cursor to start of project: Shift+Home
 - OSARA: Select from cursor to end of project: Shift+End
 - OSARA: Remove items/tracks/contents of time selection/markers/envelope points (depending on focus): Delete
-- OSARA: Report edit/play cursor position and transport state: Control+Shift+J
+- OSARA: Report edit/play cursor position, transport state and nearest markers and regions: Control+Shift+J
  - If the ruler unit is set to Measures.Beats / Minutes:Seconds, Pressing this once will report the time in measures.beats, while pressing it twice will report the time in minutes:seconds .
 - OSARA: Delete all time signature markers: Alt+Win+Delete
 - OSARA: Toggle track/take volume envelope visibility (depending on focus): Control+Alt+V

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -5028,7 +5028,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report track/item/time/MIDI selection (depending on focus)")}, "OSARA_REPORTSEL", cmdReportSelection},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Remove items/tracks/contents of time selection/markers/envelope points (depending on focus)")}, "OSARA_REMOVE", cmdRemoveFocus},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Toggle shortcut help")}, "OSARA_SHORTCUTHELP", cmdShortcutHelp},
-	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report edit/play cursor position and transport state")}, "OSARA_CURSORPOS", cmdReportCursorPosition},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report edit/play cursor position, transport state and nearest markers and regions")}, "OSARA_CURSORPOS", cmdReportCursorPosition},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current track/item (depending on focus)")}, "OSARA_TOGGLESEL", cmdToggleSelection},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Move last focused stretch marker to current edit cursor position")}, "OSARA_MOVESTRETCH", cmdMoveStretch},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report level in peak dB at play cursor for channel 1 of current track (reports input level instead when track is armed)")}, "OSARA_REPORTPEAKCURRENTC1", cmdReportPeakCurrentC1},


### PR DESCRIPTION
This will report if the cursor is before the first marker in the project, right at a marker, between two markers or after the last marker in the project. It also does this for regions, except that it reports whether the cursor is inside a region rather than right at it. Given the new functionality, this action has been renamed to: OSARA: Report edit/play cursor position, transport state and nearest markers and regions. However, the key map is unchanged and existing mappings will continue to work.

Fixes #1062.