### PR TITLE
Make Select from cursor to start/end of project actions more robust

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4818,16 +4818,20 @@ void cmdReportRegionMarkerItems(Command* command) {
 }
 
 void cmdSelectFromCursorToStartOfProject(Command* command) {
+	Main_OnCommand(40769, 0); // Unselect (clear selection of) all tracks/items/envelope points
 	Main_OnCommand(40626, 0); // Time selection: Set end point
 	Main_OnCommand(40042, 0); // Transport: Go to start of project
 	Main_OnCommand(40625, 0); // Time selection: Set start point
+	fakeFocus = FOCUS_RULER;
 	outputMessage(translate("selected to start of project"));
 }
 
 void cmdSelectFromCursorToEndOfProject(Command* command) {
+	Main_OnCommand(40769, 0); // Unselect (clear selection of) all tracks/items/envelope points
 	Main_OnCommand(40625, 0); // Time selection: Set start point
 	Main_OnCommand(40043, 0); // Transport: Go to end of project
 	Main_OnCommand(40626, 0); // Time selection: Set end point
+	fakeFocus = FOCUS_RULER;
 	outputMessage(translate("selected to end of project"));
 }
 


### PR DESCRIPTION
@GianlucaApollaro and @dgl1984 were having problems with the reliability of the OSARA: Select from cursor to start/end of project actions. Couldn't figure out what settings were different to cause unreliability, but explicitly setting focus shored it up.