### PR TITLE
Report inserting media, including items with adjusted playrate

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3389,7 +3389,10 @@ void cmdSplitItems(Command* command) {
 void cmdPaste(Command* command) {
 	MediaItem* item = GetSelectedMediaItem(0, 0);
 	int oldTakes = CountTakes(item);
-	int oldItems = CountMediaItems(0);
+	set<MediaItem*> oldItems;
+	for (int i = 0; i < CountMediaItems(0); i++) {
+		oldItems.insert(GetMediaItem(0, i));
+	}
 	int oldTracks = CountTracks(0);
 	TrackEnvelope* envelope = GetSelectedEnvelope(0);
 	int oldPoints = 0;
@@ -3409,7 +3412,7 @@ void cmdPaste(Command* command) {
 		// {} will be replaced with the number of tracks; e.g. "2 tracks".
 		s << format(translate_plural("{} track", "{} tracks", added), added);
 	}
-	if ((added = CountMediaItems(0) - oldItems) > 0) {
+	if ((added = CountMediaItems(0) - oldItems.size()) > 0) {
 		if (s.tellp() > 0) {
 			s << " ";
 		}
@@ -3422,6 +3425,15 @@ void cmdPaste(Command* command) {
 		// Translators: Reported after the number of tracks and/or items added.
 		s << " " << translate("added");
 		maybeAddRippleMessage(s, command->gaccel.accel.cmd);
+		int rateAdjusted = 0;
+		for (int i = 0; i < CountMediaItems(0); i++) {
+			MediaItem* item = GetMediaItem(0, i);
+			if (!oldItems.contains(item) &&
+					*(double*)GetSetMediaItemTakeInfo(GetActiveTake(item), "D_PLAYRATE", nullptr) != 1.0)
+				rateAdjusted++;
+		}
+		if (rateAdjusted > 0)
+			s << ", " << format(translate_plural("{} item rate adjusted", "{} items rate adjusted", rateAdjusted), rateAdjusted);
 		outputMessage(s);
 		return;
 	}
@@ -4901,6 +4913,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 42398}, nullptr}, nullptr, cmdPaste}, // Item: Paste items/tracks
 	{MAIN_SECTION, {{0, 0, 40603}, nullptr}, nullptr, cmdPaste}, // Take: Paste as takes in items
 	{MAIN_SECTION, {{0, 0, 40062}, nullptr}, nullptr, cmdPaste}, // Track: Duplicate tracks
+	{MAIN_SECTION, {{0, 0, 40018}, nullptr}, nullptr, cmdPaste}, // Insert media files...
 	{MAIN_SECTION, {{0, 0, 40005}, nullptr}, nullptr, cmdRemoveTracks}, // Track: Remove tracks
 	{MAIN_SECTION, {{0, 0, 40337}, nullptr}, nullptr, cmdRemoveTracks}, // Track: Cut tracks
 	{MAIN_SECTION, {{0, 0, 40006}, nullptr}, nullptr, cmdRemoveItems}, // Item: Remove items


### PR DESCRIPTION
This makes OSARA report a summary of tracks/items added when using REAPER's "Insert media files" action, it also checks whether any of those newly inserted items have had their playrate adjusted and reports it. I added the playrate adjustment because preferences around it are changing, the defaults for new prefs are a bit heavy-handed IMO, have already seen it catching a couple of users unawares.