### PR TITLE
Make the OSARA Configuration dialog and its controls bigger so they aren't cut off visually.

### DIFF
--- a/site_scons/makeConfigRc.py
+++ b/site_scons/makeConfigRc.py
@@ -15,7 +15,7 @@ def makeConfigRc(target, source, env):
 			break
 	out.write(
 """#include <windows.h>
-{cid} DIALOGEX 250, 125, 185, 212
+{cid} DIALOGEX 250, 125, 500, 500
 	CAPTION "OSARA Configuration"
 BEGIN
 """.format(cid=cid))
@@ -34,7 +34,7 @@ BEGIN
 		m = RE_BOOL_SETTING.match(setting)
 		cid += 1
 		out.write(
-			'\tCONTROL {displayName}, {cid}, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, {y}, 200, 14\n'
+			'\tCONTROL {displayName}, {cid}, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 10, {y}, 490, 14\n'
 			.format(displayName=m.group("displayName"), cid=cid, y=y))
 		y += 20
 	out.write('\tDEFPUSHBUTTON "OK", IDOK, 10, {y}, 30, 14\n'


### PR DESCRIPTION
Partially addresses #1027. This increases the size so things should fit better into available space, but it doesn't make that dialog scrollable.

@Buy-One, @mespotine, does this help any? From what I could tell using OCR (I can't see the screen), everything seemed to fit, but that says nothing else about how it appears visually. :)