### PR TITLE
Feedback for more MIDI event selection actions

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1227,6 +1227,26 @@ void postMidiSelectEvents(int command) {
 		count));
 }
 
+void cmdMidiSelCC (Command* command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	int oldCount = countSelectedEvents (take);
+	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
+	int newCount = countSelectedEvents (take);
+	int count = newCount;
+//	if (count >= 0) {
+		// Translators: Used in the MIDI editor when CC events are selected.  {}
+		// is replaced by the number of events selected.
+		outputMessage(format(
+			translate_plural("{} CC event selected", "{} CC events selected", count), count));
+//	} else {
+		// Translators: Used in the MIDI editor when CC events are unselected.  {}
+		// is replaced by the number of events unselected.
+//		outputMessage(format(
+//			translate_plural("{} CC event unselected", "{} CC events unselected", -count), -count));
+//	}
+}
+
 void cmdMidiToggleSelCC (Command* command) {
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2564,6 +2564,7 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40465, postMidiChangeVelocity, true, true}, // Edit: Note velocity -10
 	{40501, postMidiSelectEvents}, // Invert selection
 	{40633, postMidiChangeLength, true, true}, // Edit: Set note lengths to grid size
+	{40668, postMidiSelectEvents}, // Select all CC events in last clicked lane
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
 	{40746, postMidiSelectNotes, true}, // Edit: Select all notes in time selection

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2537,6 +2537,7 @@ PostCommand POST_COMMANDS[] = {
 	{0},
 };
 MidiPostCommand MIDI_POST_COMMANDS[] = {
+	{40003, postMidiSelectEvents, true}, // Edit: Select all notes
 	{40006, postMidiSelectEvents, true}, // Edit: Select all events
 	{40049, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
 	{40050, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2568,6 +2568,7 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
 	{40746, postMidiSelectNotes, true}, // Edit: Select all notes in time selection
+	{40747, postMidiSelectEvents, true}, // Edit: Select all CC events in time selection (in last clicked CC lane)
 	{40877, postMidiSelectNotes, true}, // Edit: Select all notes starting in time selection
 	{40765, postMidiChangeLength}, // Edit: Make notes legato, preserving note start times
 	{41026, postMidiChangePitch, true, true}, // Edit: Move notes up one semitone ignoring scale/key

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2564,7 +2564,6 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40465, postMidiChangeVelocity, true, true}, // Edit: Note velocity -10
 	{40501, postMidiSelectEvents}, // Invert selection
 	{40633, postMidiChangeLength, true, true}, // Edit: Set note lengths to grid size
-	{40668, postMidiSelectEvents}, // Select all CC events in last clicked lane
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
 	{40746, postMidiSelectNotes, true}, // Edit: Select all notes in time selection
@@ -5003,6 +5002,7 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0, 40836}, nullptr}, nullptr, cmdMidiMoveToTrack}, // Activate previous MIDI track
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40836}, nullptr}, nullptr, cmdMidiMoveToTrack}, // Activate previous MIDI track
 	{MIDI_EDITOR_SECTION, {{0, 0, 40664}, nullptr}, nullptr, cmdMidiToggleSelCC}, // Edit: Toggle selection of all CC events under selected notes
+	{MIDI_EDITOR_SECTION, {{0, 0, 40668}, nullptr}, nullptr, cmdMidiSelCC}, // Select all CC events in last clicked lane
 #ifdef _WIN32
 	{MIDI_EDITOR_SECTION, {{0, 0, 40762}, nullptr}, nullptr, cmdMidiFilterWindow}, // Filter: Show/hide filter window...
 	{MIDI_EDITOR_SECTION, {{ 0, 0, 40471}, nullptr}, nullptr, cmdMidiFilterWindow }, // Filter: Enable/disable event filter and show/hide filter window...


### PR DESCRIPTION
I haven't managed to get the build environment up and running and I'm not entirely sure that this is all that's needed, but I hope that this adds feedback for the following actions:
* Edit: Select all notes
* Select all CC events in last clicked lane
* Edit: Select all CC events in time selection (in last clicked CC lane)
It may not be much, but hey, one has to start somewhere... 🙂