### PR TITLE
Feedback for MIDI copy, cut and paste

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -392,7 +392,10 @@ SWS/FNG: Time stretch selected items (fine): Control+Alt+=
 - Edit: Decrease pitch cursor one semitone: Alt+DownArrow or Ctrl+NumPad2
 - Edit: Increase pitch cursor one octave: Alt+Shift+UpArrow
 - Edit: Decrease pitch cursor one octave: Alt+Shift+DownArrow
+- Edit: copy: Control+C
+- Edit: cut: Control+X
 - Edit: Delete events: Delete
+- Edit: paste: Control+V
 - Edit: Insert note at edit cursor: I or NumPad5
 - Edit: Insert note at edit cursor (no advance edit cursor): Shift+I or Shift+NumPad5
 - Edit: Select all events: Control+A

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1266,14 +1266,15 @@ void cmdMidiPasteEvents(Command* command) {
 	int oldCount = MIDI_CountEvts(take, nullptr, nullptr, nullptr);
 	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
 	int newCount = MIDI_CountEvts(take, nullptr, nullptr, nullptr);
-	int count = 0;
-	if (newCount > oldCount) {
-		count = newCount - oldCount;
+	int added = newCount - oldCount;
+if (added <= 0) {
+		outputMessage(translate("nothing pasted"));
+		return;
 	}
 	// Translators: Reported when pasting events in the MIDI editor. {} will be replaced with
 	// the number of events; e.g. "2 events pasted".
 	outputMessage(format(
-		translate_plural("{} event added", "{} events added", count), count));
+		translate_plural("{} event added", "{} events added", added), added));
 }
 
 void cmdMidiDeleteEvents(Command* command) {
@@ -1292,9 +1293,6 @@ void postMidiCopyEvents(int command) {
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
 	int count = countSelectedEvents (take);
-	if (fakeFocus != FOCUS_NOTE && fakeFocus != FOCUS_CC) {
-		fakeFocus = FOCUS_NOTE;
-	}
 	// Translators: Reported when copying events in the MIDI editor. {} will be replaced with
 	// the number of events; e.g. "2 events copied".
 	outputMessage(format(

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1272,7 +1272,7 @@ if (added <= 0) {
 		return;
 	}
 	// Translators: Reported when pasting events in the MIDI editor. {} will be replaced with
-	// the number of events; e.g. "2 events pasted".
+	// the number of events; e.g. "2 events added".
 	outputMessage(format(
 		translate_plural("{} event added", "{} events added", added), added));
 }

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1260,6 +1260,22 @@ void cmdMidiInsertNote(Command* command) {
 	outputMessage(s);
 }
 
+void cmdMidiPasteEvents(Command* command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	int oldCount = MIDI_CountEvts(take, nullptr, nullptr, nullptr);
+	MIDIEditor_OnCommand(editor, command->gaccel.accel.cmd);
+	int newCount = MIDI_CountEvts(take, nullptr, nullptr, nullptr);
+	int count = 0;
+	if (newCount > oldCount) {
+		count = newCount - oldCount;
+	}
+	// Translators: Reported when pasting events in the MIDI editor. {} will be replaced with
+	// the number of events; e.g. "2 events pasted".
+	outputMessage(format(
+		translate_plural("{} event added", "{} events added", count), count));
+}
+
 void cmdMidiDeleteEvents(Command* command) {
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);
@@ -1270,6 +1286,19 @@ void cmdMidiDeleteEvents(Command* command) {
 	// replaced by the number of events. E.g. "3 events removed"
 	outputMessage(format(
 		translate_plural("{} event removed", "{} events removed", removed), removed));
+}
+
+void postMidiCopyEvents(int command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	int count = countSelectedEvents (take);
+	if (fakeFocus != FOCUS_NOTE && fakeFocus != FOCUS_CC) {
+		fakeFocus = FOCUS_NOTE;
+	}
+	// Translators: Reported when copying events in the MIDI editor. {} will be replaced with
+	// the number of events; e.g. "2 events copied".
+	outputMessage(format(
+		translate_plural("{} event copied", "{} events copied", count), count));
 }
 
 void postMidiSelectNotes(int command) {

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -38,6 +38,8 @@ void postMidiMovePitchCursor(int command);
 void cmdMidiInsertCC(Command* command);
 void cmdMidiInsertNote(Command* command);
 void cmdMidiDeleteEvents(Command* command);
+void cmdMidiPasteEvents(Command* command);
+void postMidiCopyEvents(int command);
 void postMidiSelectNotes(int command);
 void postMidiSelectEvents(int command);
 void cmdMidiToggleSelCC (Command* command) ;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2555,6 +2555,7 @@ PostCommand POST_COMMANDS[] = {
 MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40003, postMidiSelectNotes, true}, // Edit: Select all notes
 	{40006, postMidiSelectEvents, true}, // Edit: Select all events
+	{40010, postMidiCopyEvents, true}, // Edit: Copy
 	{40049, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
 	{40050, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
 	{40177, postMidiChangePitch, true, true}, // Edit: Move notes up one semitone
@@ -4999,6 +5000,8 @@ Command COMMANDS[] = {
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40037}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to end of file
 	{MIDI_EDITOR_SECTION, {{0, 0, 40440}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor to start of selected events
 	{MIDI_EDITOR_SECTION, {{0, 0, 40639}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor to end of selected events
+	{MIDI_EDITOR_SECTION, {{0, 0, 40011}, nullptr}, nullptr, cmdMidiPasteEvents}, // Edit: Paste
+	{MIDI_EDITOR_SECTION, {{0, 0, 40012}, nullptr}, nullptr, cmdMidiDeleteEvents}, // Edit: Cut
 	{MIDI_EDITOR_SECTION, {{0, 0, 40046}, nullptr}, nullptr, cmdMidiNoteSplitOrJoin}, // Edit: Split notes
 	{MIDI_EDITOR_SECTION, {{0, 0, 40047}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor left by grid
 	{MIDI_EDITOR_SECTION, {{0, 0, 40048}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor right by grid


### PR DESCRIPTION
Seems to work fine here.
For the cut operation I used the existing cmdMidiDeleteEvents function, since the feedback is in line with what we're doing outside of the MIDI editor. That is to say, we don't always verbally distinguish between cutting and deleting - instead we say that something has been 'removed'.