### PR TITLE
Feedback for more MIDI select/copy/cut/paste actions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,9 +393,12 @@ SWS/FNG: Time stretch selected items (fine): Control+Alt+=
 - Edit: Increase pitch cursor one octave: Alt+Shift+UpArrow
 - Edit: Decrease pitch cursor one octave: Alt+Shift+DownArrow
 - Edit: copy: Control+C
+- Edit: Copy events within time selection, if any (smart copy): Control+shift+C
 - Edit: cut: Control+X
+- Edit: Cut events within time selection, if any (smart cut): Control+shift+X
 - Edit: Delete events: Delete
 - Edit: paste: Control+V
+- Edit: Paste preserving position in measure: control+Shift+V
 - Edit: Insert note at edit cursor: I or NumPad5
 - Edit: Insert note at edit cursor (no advance edit cursor): Shift+I or Shift+NumPad5
 - Edit: Select all events: Control+A
@@ -907,6 +910,7 @@ This list is worth referencing when making your own key map additions, assigning
 - Reset all MIDI control surface devices
 
 #### Unmapped in MIDI Editor section
+- Edit: Select all events in time selection (even if CC lane is hidden)
 - Edit: Select all notes in time selection
 - Options: MIDI inputs as step input mode
 - Options: F1-F12 as step input mode

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2583,7 +2583,9 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40633, postMidiChangeLength, true, true}, // Edit: Set note lengths to grid size
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
+	{40733, postMidiCopyEvents, true}, // Edit: Copy events within time selection, if any (smart copy)
 	{40746, postMidiSelectNotes, true}, // Edit: Select all notes in time selection
+	{40875, postMidiSelectEvents, true}, // Edit: Select all events in time selection (even if CC lane is hidden)
 	{40877, postMidiSelectNotes, true}, // Edit: Select all notes starting in time selection
 	{40765, postMidiChangeLength}, // Edit: Make notes legato, preserving note start times
 	{41026, postMidiChangePitch, true, true}, // Edit: Move notes up one semitone ignoring scale/key
@@ -5007,12 +5009,14 @@ Command COMMANDS[] = {
 	{MIDI_EDITOR_SECTION, {{0, 0, 40048}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor right by grid
 	{MIDI_EDITOR_SECTION, {{0, 0, 40185}, nullptr}, nullptr, cmdMidiMoveCursor}, // Edit: Move edit cursor left one pixel
 	{MIDI_EDITOR_SECTION, {{0, 0, 40186}, nullptr}, nullptr, cmdMidiMoveCursor}, // Edit: Move edit cursor right one pixel
+	{MIDI_EDITOR_SECTION, {{0, 0, 40429}, nullptr}, nullptr, cmdMidiPasteEvents}, // Edit: Paste preserving position in measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40456}, nullptr}, nullptr, cmdMidiNoteSplitOrJoin}, // Edit: Join notes
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40456}, nullptr}, nullptr, cmdMidiNoteSplitOrJoin}, // Edit: Join notes
 	{MIDI_EDITOR_SECTION, {{0, 0, 40682}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor right one measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40683}, nullptr}, nullptr, cmdMidiMoveCursor}, // Navigate: Move edit cursor left one measure
 	{MIDI_EDITOR_SECTION, {{0, 0, 40667}, nullptr}, nullptr, cmdMidiDeleteEvents}, // Edit: Delete events
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40667}, nullptr}, nullptr, cmdMidiDeleteEvents}, // Edit: Delete events
+	{MIDI_EDITOR_SECTION, {{0, 0, 40734}, nullptr}, nullptr, cmdMidiDeleteEvents}, // Edit: Cut events within time selection, if any (smart cut)
 	{MIDI_EDITOR_SECTION, {{0, 0, 40051}, nullptr}, nullptr, cmdMidiInsertNote}, // Edit: Insert note at edit cursor
 	{MIDI_EDITOR_SECTION, {{0, 0, 1000}, nullptr}, nullptr, cmdMidiInsertNote}, // Edit: Insert note at edit cursor (no advance edit cursor)
 	{MIDI_EDITOR_SECTION, {{0, 0, 40835}, nullptr}, nullptr, cmdMidiMoveToTrack}, // Activate next MIDI track


### PR DESCRIPTION
I think that there are more MIDI actions that would benefit from feedback. All the below ones are currently on the key map except for one. I made that one speak, because it's an action I personally find useful. That being said, I don't know if it ever makes it on to the official key map, but we already have other unmapped actions, so hopefully everyone's fine with having that action available in general.
- Edit: Copy events within time selection, if any (smart copy): Control+shift+C
- Edit: Cut events within time selection, if any (smart cut): Control+shift+X
- Edit: Paste preserving position in measure: control+Shift+V
- Edit: Select all events in time selection (even if CC lane is hidden): Unmapped