### PR TITLE
Added feedback for Edit: Select all CC events in time selection (even if CC lane is hidden)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -910,6 +910,7 @@ This list is worth referencing when making your own key map additions, assigning
 - Reset all MIDI control surface devices
 
 #### Unmapped in MIDI Editor section
+- Edit: Select all CC events in time selection (even if CC lane is hidden)
 - Edit: Select all events in time selection (even if CC lane is hidden)
 - Edit: Select all notes in time selection
 - Options: MIDI inputs as step input mode

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2588,6 +2588,7 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40733, postMidiCopyEvents, true}, // Edit: Copy events within time selection, if any (smart copy)
 	{40746, postMidiSelectNotes, true}, // Edit: Select all notes in time selection
 	{40747, postMidiSelectCCs, true}, // Edit: Select all CC events in time selection (in last clicked CC lane)
+	{40751, postMidiSelectCCs, true}, // Edit: Select all CC events in time selection (even if CC lane is hidden)
 	{40875, postMidiSelectEvents, true}, // Edit: Select all events in time selection (even if CC lane is hidden)
 	{40877, postMidiSelectNotes, true}, // Edit: Select all notes starting in time selection
 	{40765, postMidiChangeLength}, // Edit: Make notes legato, preserving note start times


### PR DESCRIPTION
Useful for deleting all CCs in a given section at once or for copying them from one place to another. The commands for selecting CCs in the current lane provide generally more control/flexibility, but in case one's happy/unhappy with all CCs in a given section, using this action is quicker.