### PR TITLE
Added feedback for CC movement commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -913,6 +913,10 @@ This list is worth referencing when making your own key map additions, assigning
 - Edit: Select all CC events in time selection (even if CC lane is hidden)
 - Edit: Select all events in time selection (even if CC lane is hidden)
 - Edit: Select all notes in time selection
+- Edit: Move CC events left 1 pixel
+- Edit: Move CC events right 1 pixel
+- Edit: Move CC events left by grid
+- Edit: Move CC events right by grid
 - Options: MIDI inputs as step input mode
 - Options: F1-F12 as step input mode
 

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -2067,6 +2067,62 @@ void postMidiChangePitch(int command) {
 	outputMessage(s);
 }
 
+void postMidiMoveCCs(int command) {
+	HWND editor = MIDIEditor_GetActive();
+	MediaItem_Take* take = MIDIEditor_GetTake(editor);
+	// Get selected CCs.
+	vector<MidiControlChange> selectedCCs = getSelectedCCs(take);
+	int count = static_cast<int>(selectedCCs.size());
+	if (count == 0) {
+		return;
+	}
+	ostringstream s;
+	if (count > 1) {
+		switch (command) {
+			case 40672:
+				// Translators: Used when moving CCs in the MIDI
+				// editor. {} is replaced by the number of CCs, e.g. 
+				// "3 CC events pixel left"
+				s << format(
+					translate_plural("{} CC event pixel left", "{} CC events pixel left", count), count);
+				break;
+			case 40673:
+			// Translators: Used when moving CCs in the MIDI
+				// editor. {} is replaced by the number of CCs, e.g. 
+				// "3 CC events pixel right"
+				s << format(
+					translate_plural("{} CC event pixel right", "{} CC events pixel right", count), count);
+				break;
+			case 40674:
+				// Translators: Used when moving CCs in the MIDI
+				// editor. {} is replaced by the number of CCs, e.g. 
+				// "3 CC events grid unit left"
+				s << format(
+					translate_plural("{} CC event grid unit left", "{} CC events grid unit left", count), count);
+				break;
+			case 40675:
+				// Translators: Used when moving CCs in the MIDI
+				// editor. {} is replaced by the number of CCs, e.g. 
+				// "3 CC events grid unit right"
+				s << format(
+					translate_plural("{} CC event grid unit right", "{} CC events grid unit right", count), count);
+				break;				
+			default:
+				// Translators: Used when moving CCs in the MIDI
+				// editor. {} is replaced by the number of CCs, e.g. 
+				// "3 CC events moved"
+				s << format(
+					translate_plural("{} CC event moved", "{} CC events moved", count), count);
+				break;
+		}
+	} else{
+		auto cc = *selectedCCs.cbegin();
+		s << formatTime(cc.position) << " ";
+		s << describeCC(cc, take);
+	}
+	outputMessage(s);
+}
+
 void postMidiMoveStart(int command) {
 	HWND editor = MIDIEditor_GetActive();
 	MediaItem_Take* take = MIDIEditor_GetTake(editor);

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -63,6 +63,7 @@ void toggleListViewItemSelection(HWND list);
 void postMidiChangeVelocity(int command);
 void postMidiChangeLength(int command);
 void postMidiChangePitch(int command);
+void postMidiMoveCCs(int command);
 void postMidiMoveStart(int command);
 void postMidiChangeCCValue(int command);
 void postMidiSwitchCCLane(int command);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2583,6 +2583,10 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40633, postMidiChangeLength, true, true}, // Edit: Set note lengths to grid size
 	{40668, postMidiSelectCCs, false}, // Select all CC events in last clicked lane
 	{40669, postMidiSelectCCs, false}, // Unselect all CC events in last clicked lane
+	{40672, postMidiMoveCCs, false}, // Edit: Move CC events left 1 pixel
+	{40673, postMidiMoveCCs, false}, // Edit: Move CC events right 1 pixel
+	{40674, postMidiMoveCCs, false}, // Edit: Move CC events left by grid
+	{40675, postMidiMoveCCs, false}, // Edit: Move CC events right by grid
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
 	{40733, postMidiCopyEvents, true}, // Edit: Copy events within time selection, if any (smart copy)


### PR DESCRIPTION
I tried my hand at #1121, but I'm afraid that I have reached the end of my abilities.
It does partially work, but with just one CC selected, triggering those actions repeatedly after one another always results in the original start position being spoken. Apart from that it's as if the Osara CC navigation commands needed time to catch on to the new positions. I'm sure it's just my code though - it's probably missing a lot of crucial stuff.
Another thing is that outputting the full CC description in this case, like I've done, may be overkill. Maybe we could do without reporting the CC values similarly how we don't report note lengths when moving them either.