### PR TITLE
Report heal splits in items

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Most of these are actions built into REAPER, but a few are useful actions from t
 - Item navigation: Select and move to next item: Control+RightArrow
 - Item: Split items at edit or play cursor: S
 - Item: Split items at time selection: Shift+S
+- Item: Heal splits in items: Control+H
 - Item edit: Move items/envelope points right: . or NumPad6
 - Item edit: Move items/envelope points left: , or NumPad4
 - Item edit: Move items/envelope points right by grid size: Alt+Shift+. or Control+Alt+NumPad6

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3574,6 +3574,20 @@ void cmdRemoveItems(Command* command) {
 	cmdhRemoveItems(command->gaccel.accel.cmd);
 }
 
+void cmdHealSplitsInItems(Command* command) {
+	int preHealed = CountSelectedMediaItems(0);
+	Main_OnCommand(command->gaccel.accel.cmd, 0);
+	int postHealed = CountSelectedMediaItems(0);
+	if (preHealed - postHealed > 0){
+		// Translators: Reported when splits in items are healed. {} will be replaced with the
+		// number of splits ; e.g. "2 splits healed".
+		outputMessage(format(
+		translate_plural("{} split healed", "{} splits healed",preHealed - postHealed),preHealed - postHealed));
+	}else {
+		outputMessage(translate("no splits healed"));
+	}
+}
+
 void cmdCut(Command* command) {
 	switch (GetCursorContext2(true)) {
 		case 0: // Track
@@ -4929,6 +4943,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40337}, nullptr}, nullptr, cmdRemoveTracks}, // Track: Cut tracks
 	{MAIN_SECTION, {{0, 0, 40006}, nullptr}, nullptr, cmdRemoveItems}, // Item: Remove items
 	{MAIN_SECTION, {{0, 0, 40699}, nullptr}, nullptr, cmdRemoveItems}, // Edit: Cut items
+	{MAIN_SECTION, {{0, 0, 40548}, nullptr}, nullptr, cmdHealSplitsInItems}, //Item: Heal splits in items 
 	{MAIN_SECTION, {{0, 0, 40333}, nullptr}, nullptr, cmdDeleteEnvelopePoints}, // Envelope: Delete all selected points
 	{MAIN_SECTION, {{0, 0, 40089}, nullptr}, nullptr, cmdDeleteEnvelopePoints}, // Envelope: Delete all points in time selection
 	{MAIN_SECTION, {{0, 0, 40336}, nullptr}, nullptr, cmdDeleteEnvelopePoints}, // Envelope: Cut selected points

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3575,15 +3575,16 @@ void cmdRemoveItems(Command* command) {
 }
 
 void cmdHealSplitsInItems(Command* command) {
-	int preHealed = CountSelectedMediaItems(0);
+	const int preHealed = CountSelectedMediaItems(nullptr);
 	Main_OnCommand(command->gaccel.accel.cmd, 0);
-	int postHealed = CountSelectedMediaItems(0);
+	int postHealed = CountSelectedMediaItems(nullptr);
 	ostringstream s;
-	if (preHealed - postHealed > 0){
+	const int healed = preHealed - postHealed;
+	if (healed > 0) {
 		// Translators: Reported when splits in items are healed. {} will be replaced with the
 		// number of splits that have been successfully healed; e.g. "2 splits healed".
 		s << format(
-			translate_plural("{} split healed", "{} splits healed",preHealed - postHealed),preHealed - postHealed) << ", ";
+			translate_plural("{} split healed", "{} splits healed",healed),healed) << ", ";
 		// Translators: This reports selected items after healing. {} will be replaced with the
 		// number of selected items; e.g. "2 items selected".
 		s << format(

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3578,14 +3578,21 @@ void cmdHealSplitsInItems(Command* command) {
 	int preHealed = CountSelectedMediaItems(0);
 	Main_OnCommand(command->gaccel.accel.cmd, 0);
 	int postHealed = CountSelectedMediaItems(0);
+	ostringstream s;
 	if (preHealed - postHealed > 0){
 		// Translators: Reported when splits in items are healed. {} will be replaced with the
-		// number of splits ; e.g. "2 splits healed".
-		outputMessage(format(
-		translate_plural("{} split healed", "{} splits healed",preHealed - postHealed),preHealed - postHealed));
+		// number of splits that have been successfully healed; e.g. "2 splits healed".
+		s << format(
+			translate_plural("{} split healed", "{} splits healed",preHealed - postHealed),preHealed - postHealed) << ", ";
+		// Translators: This reports selected items after healing. {} will be replaced with the
+		// number of selected items; e.g. "2 items selected".
+		s << format(
+			translate_plural("{} item selected", "{} items selected",postHealed),postHealed);
 	}else {
-		outputMessage(translate("no splits healed"));
+		// Translators: Reported when healing was not possible.
+		outputMessage(translate("nothing healed"));
 	}
+	outputMessage(s);
 }
 
 void cmdCut(Command* command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3605,22 +3605,22 @@ void cmdCropTakes(Command* command) {
 void cmdHealSplitsInItems(Command* command) {
 	const int preHealed = CountSelectedMediaItems(nullptr);
 	Main_OnCommand(command->gaccel.accel.cmd, 0);
-	int postHealed = CountSelectedMediaItems(nullptr);
-	ostringstream s;
+	const int postHealed = CountSelectedMediaItems(nullptr);
 	const int healed = preHealed - postHealed;
-	if (healed > 0) {
-		// Translators: Reported when splits in items are healed. {} will be replaced with the
-		// number of splits that have been successfully healed; e.g. "2 splits healed".
-		s << format(
-			translate_plural("{} split healed", "{} splits healed",healed),healed) << ", ";
-		// Translators: This reports selected items after healing. {} will be replaced with the
-		// number of selected items; e.g. "2 items selected".
-		s << format(
-			translate_plural("{} item selected", "{} items selected",postHealed),postHealed);
-	}else {
+	if (healed == 0) {
 		// Translators: Reported when healing was not possible.
 		outputMessage(translate("nothing healed"));
+		return;
 	}
+	ostringstream s;
+	// Translators: Reported when splits in items are healed. {} will be replaced with the
+	// number of splits that have been successfully healed; e.g. "2 splits healed".
+	s << format(
+		translate_plural("{} split healed", "{} splits healed",healed),healed) << ", ";
+	// Translators: This reports selected items after healing. {} will be replaced with the
+	// number of selected items; e.g. "2 items selected".
+	s << format(
+		translate_plural("{} item selected", "{} items selected",postHealed),postHealed);
 	outputMessage(s);
 }
 


### PR DESCRIPTION
This reports number of splits healed,(nothing healed if none), and number of items selected after healing.