### PR TITLE
Added feedback for 'Select' and 'Unselect all CC events'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -915,11 +915,12 @@ This list is worth referencing when making your own key map additions, assigning
 - Reset all MIDI control surface devices
 
 #### Unmapped in MIDI Editor section
-- Edit: Select all CC events in time selection (even if CC lane is hidden)
 - Edit: Select all events in time selection (even if CC lane is hidden)
 - Edit: Select all notes in time selection
 - Options: MIDI inputs as step input mode
 - Options: F1-F12 as step input mode
+- Select all CC events
+- Unselect all CC events
 
 #### Unmapped OSARA actions
 - OSARA: Pause/resume Peak Watcher

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2583,6 +2583,8 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40633, postMidiChangeLength, true, true}, // Edit: Set note lengths to grid size
 	{40668, postMidiSelectCCs, false}, // Select all CC events in last clicked lane
 	{40669, postMidiSelectCCs, false}, // Unselect all CC events in last clicked lane
+	{40670, postMidiSelectCCs, true}, // Select all CC events
+	{40671, postMidiSelectCCs, true}, // Unselect all CC events
 	{40676, postMidiChangeCCValue, true, true}, // Edit: Increase value a little bit for CC events
 	{40677, postMidiChangeCCValue, true, true}, // Edit: Decrease value a little bit for CC events
 	{40733, postMidiCopyEvents, true}, // Edit: Copy events within time selection, if any (smart copy)


### PR DESCRIPTION
Provides feedback for actions to quickly select/unselect all CC events in a MIDI item.
These actions are not mapped to any keyboard shortcuts at the moment.