### PR TITLE
Add project and take markers action

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4793,8 +4793,33 @@ void cmdInsertMarker(Command* command) {
 		Main_OnCommand(command->gaccel.accel.cmd, 0);
 		return;
 	}
+	if(CountSelectedMediaItems(0)>0) {
+		vector<int> preMarkers(CountSelectedMediaItems(nullptr));
+		for(int i = 0; i < preMarkers.size(); ++ i) {
+			MediaItem* item = GetSelectedMediaItem(nullptr, i);
+			MediaItem_Take* take = GetActiveTake(item);
+			preMarkers[i] = GetNumTakeMarkers(take);
+		}
+		Main_OnCommand(42390, 0); // Item: Quick add take marker at play position or edit cursor
+		int addedMarkers = 0;
+		for(int i = 0; i < preMarkers.size(); ++ i) {
+			MediaItem* item = GetSelectedMediaItem(nullptr, i);
+			MediaItem_Take* take = GetActiveTake(item);
+			if (preMarkers[i] < GetNumTakeMarkers(take)) {
+				++ addedMarkers;
+			}
+		}
+		if (addedMarkers == 0) {
+			return; // not inserted
+		} else {
+			// Translators: Reported when using REAPER's quick add take marker action. [] will be replaced with the number of take markers that have been inserted. E.G. "2 take markers inserted".
+			outputMessage(format(
+				translate_plural("{} take marker inserted", "{} take markers inserted", addedMarkers), addedMarkers));
+			return;
+		}
+	}
 	int count = CountProjectMarkers(nullptr, nullptr, nullptr);
-	Main_OnCommand(command->gaccel.accel.cmd, 0);
+	Main_OnCommand(40157, 0);
 	if (CountProjectMarkers(nullptr, nullptr, nullptr) == count) {
 		return; // Not inserted.
 	}
@@ -5252,6 +5277,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Check for update")}, "OSARA_UPDATE", cmdCheckForUpdate},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Open online documentation")}, "OSARA_OPENDOC", cmdOpenDoc},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers")}, "OSARA_MANAGETEMPOTIMESIGMARKERS", cmdManageTempoTimeSigMarkers},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Add project or take marker at cursor (depending on focus)")}, "OSARA_ADDPROJTAKEMARKER", cmdInsertMarker},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current chord/note")}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to next chord")}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to previous chord")}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4812,9 +4812,9 @@ void cmdInsertMarker(Command* command) {
 		if (addedMarkers == 0) {
 			return; // not inserted
 		} else {
-			// Translators: Reported when using REAPER's quick add take marker action. [] will be replaced with the number of take markers that have been inserted. E.G. "2 take markers inserted".
+			// Translators: Reported when using REAPER's quick add take marker action. If more than one take marker is inserted, [] will be replaced with the number of markers. E.G. "2 take markers inserted".
 			outputMessage(format(
-				translate_plural("{} take marker inserted", "{} take markers inserted", addedMarkers), addedMarkers));
+				translate_plural("take marker inserted", "{} take markers inserted", addedMarkers), addedMarkers));
 			return;
 		}
 	}
@@ -4833,6 +4833,20 @@ void cmdInsertMarker(Command* command) {
 	// Translators: Reported when inserting a marker. {} will be replaced with the
 	// number of the new marker; e.g. "marker 2 inserted".
 	outputMessage(format(translate("marker {} inserted"), number));
+}
+
+void cmdInsertOrEditMarker(Command* command) {
+	double start, end;
+	GetSet_LoopTimeRange(false, true, &start, &end, false);
+	if (start != end && CountSelectedMediaItems(nullptr)>0) {
+		Main_OnCommand(43181, 0); // Item: Add/edit take marker at time selection
+		return;
+	} else if(CountSelectedMediaItems(nullptr) > 0) {
+		Main_OnCommand(42385, 0); // Item: Add/edit take marker at play position or edit cursor
+	} else {
+		Main_OnCommand(40171, 0); // Markers: Insert and/or edit marker at current position
+		return;
+	}
 }
 
 void cmdInsertRegion(Command* command) {
@@ -5278,6 +5292,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Open online documentation")}, "OSARA_OPENDOC", cmdOpenDoc},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers")}, "OSARA_MANAGETEMPOTIMESIGMARKERS", cmdManageTempoTimeSigMarkers},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Add project or take marker at cursor (depending on focus)")}, "OSARA_ADDPROJTAKEMARKER", cmdInsertMarker},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Add/edit project or take marker at cursor (depending on focus)")}, "OSARA_ADDEDITPROJTAKEMARKER", cmdInsertOrEditMarker},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current chord/note")}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to next chord")}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to previous chord")}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},


### PR DESCRIPTION
This improves support for take markers, by making adding them context sensitive. Navigation of them will be added to the key map in the next commit.