### PR TITLE
CC navigation: Honor the position reporting setting

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -1530,7 +1530,9 @@ void moveToCC(int direction, bool clearSelection=true, bool select=true) {
 	SetEditCurPos(cc.position, true, false);
 	fakeFocus = FOCUS_CC;
 	ostringstream s;
-	s << formatCursorPosition() << " ";
+	if (settings::reportPositionMIDI) {
+		s << formatCursorPosition() << " ";
+	}
 	if (cc.muted) {
 		s << translate("muted") << " ";
 	}

--- a/src/settings.h
+++ b/src/settings.h
@@ -39,7 +39,7 @@ BoolSetting(reportFx, MAIN_SECTION,
 	"Report &FX when moving to tracks/takes",
 	false)
 BoolSetting(reportPositionMIDI, MIDI_EDITOR_SECTION,
-	"Report &position when navigating chords in MIDI editor",
+	"Report &position when navigating events in MIDI editor",
 	true)
 BoolSetting(reportNotes, MIDI_EDITOR_SECTION,
 	"Report MIDI &notes in MIDI editor",


### PR DESCRIPTION
This fixes #1130.
Because of this change I propose to rename the setting "Report position when navigating chords in MIDI editor" to "Report position when navigating events in MIDI editor". I have done that already in settings.h - dunow if it also hasto be changed anywhere else though.