### PR TITLE
Windows key map: fixed inconsistency by binding Item navigation: Move…

### DIFF
--- a/config/windows/reaper-kb.ini
+++ b/config/windows/reaper-kb.ini
@@ -139,8 +139,6 @@ KEY 1 66 40298 0		 # Main : B : Track: Toggle FX bypass for current/last touched
 KEY 13 88 40307 0		 # Main : Ctrl+Shift+X : OVERRIDE DEFAULT : Item: Cut selected area of items
 KEY 13 32814 40312 0		 # Main : Ctrl+Shift+DELETE : Item: Remove selected area of items
 KEY 9 192 40315 0		 # Main : Ctrl+' : Item: Auto trim/split items (remove silence)...
-KEY 9 103 40318 0		 # Main : Ctrl+NUM 7 : Item navigation: Move cursor left to edge of item
-KEY 9 105 40319 0		 # Main : Ctrl+NUM 9 : Item navigation: Move cursor right to edge of item
 KEY 9 219 40320 0		 # Main : Ctrl+[ : OVERRIDE DEFAULT : Time selection: Nudge left edge left
 KEY 9 221 40321 0		 # Main : Ctrl+] : OVERRIDE DEFAULT : Time selection: Nudge left edge right
 KEY 17 219 40322 0		 # Main : Alt+[ : Time selection: Nudge right edge left
@@ -244,7 +242,9 @@ KEY 13 72 41150 0		 # Main : Ctrl+Shift+H : Envelope: Hide all envelopes for all
 KEY 5 87 41160 0		 # Main : Shift+W : OVERRIDE DEFAULT : Automation: Write current values for all writing envelopes to time selection
 KEY 9 87 41162 0		 # Main : Ctrl+W : Automation: Write current values for all writing envelopes from cursor to end of project
 KEY 13 188 41173 0		 # Main : Ctrl+Shift+, : Item navigation: Move cursor to start of items
+KEY 9 103 41173 0		 # Main : Ctrl+NUM 7 : Item navigation: Move cursor to start of items
 KEY 13 190 41174 0		 # Main : Ctrl+Shift+. : Item navigation: Move cursor to end of items
+KEY 9 105 41174 0		 # Main : Ctrl+NUM 9 : Item navigation: Move cursor to end of items
 KEY 5 114 41175 0		 # Main : Shift+F3 : Reset all MIDI devices
 KEY 1 191 41187 0		 # Main : / : Scrub: Toggle looped-segment scrub at edit cursor
 KEY 41 117 41199 0		 # Main : Ctrl+Win+F6 : Track: Toggle track solo defeat


### PR DESCRIPTION
… cursor to start and end of items to Control+NumPad7 and Control+NumPad9