### PR TITLE
Fix Mac key map regression.

### DIFF
--- a/config/mac/reaper-kb.ini
+++ b/config/mac/reaper-kb.ini
@@ -70,7 +70,7 @@ KEY 9 32804 40042 0		 # Main : Cmd+Home : Transport: Go to start of project
 KEY 9 32803 40043 0		 # Main : Cmd+End : Transport: Go to end of project
 KEY 1 32 40044 0		 # Main : Space : OVERRIDE DEFAULT : Transport: Play/stop
 KEY 9 88 40059 0		 # Main : Cmd+X : OVERRIDE DEFAULT : Edit: Cut items/tracks/envelope points (depending on focus) ignoring time selection
-KEY 41 67 40060 0		 # Main : Cmd+Control+C : Item: Copy selected area of items
+KEY 13 67 40060 0		 # Main : Cmd+Shift+C : OVERRIDE DEFAULT : Item: Copy selected area of items
 KEY 17 68 40062 0		 # Main : Opt+D : OVERRIDE DEFAULT : Track: Duplicate tracks
 KEY 1 71 40071 0		 # Main : G : OVERRIDE DEFAULT : Options: Show snap/grid settings
 KEY 33 32 40073 0		 # Main : Control+Space : OVERRIDE DEFAULT : Transport: Play/pause
@@ -83,7 +83,6 @@ KEY 5 32805 40102 0		 # Main : Shift+Left : OVERRIDE DEFAULT : Time selection: M
 KEY 5 32807 40103 0		 # Main : Shift+Right : OVERRIDE DEFAULT : Time selection: Move cursor right, creating time selection
 KEY 1 32805 40104 0		 # Main : Left : OVERRIDE DEFAULT : View: Move cursor left one pixel
 KEY 1 32807 40105 0		 # Main : Right : OVERRIDE DEFAULT : View: Move cursor right one pixel
-KEY 25 69 40109 0		 # Main : Cmd+Opt+E : OVERRIDE DEFAULT : Item: Open items in primary external editor
 KEY 17 32806 40115 0		 # Main : Opt+Up : OVERRIDE DEFAULT : Track: Nudge track volume up
 KEY 17 32808 40116 0		 # Main : Opt+Down : OVERRIDE DEFAULT : Track: Nudge track volume down
 KEY 0 46 40119 0		 # Main : . : OVERRIDE DEFAULT : Item edit: Move items/envelope points right
@@ -94,7 +93,10 @@ KEY 0 60 40123 0		 # Main : < : OVERRIDE DEFAULT : Item edit: Move contents of i
 KEY 0 62 40124 0		 # Main : > : OVERRIDE DEFAULT : Item edit: Move contents of items right
 KEY 1 84 40125 0		 # Main : T : OVERRIDE DEFAULT : Take: Switch items to next take
 KEY 5 84 40126 0		 # Main : Shift+T : OVERRIDE DEFAULT : Take: Switch items to previous take
+KEY 41 32814 40130 0		 # Main : Cmd+Control+Delete : Take: Delete active take from items (prompt to confirm)
+KEY 21 84 40131 0		 # Main : Opt+Shift+T : OVERRIDE DEFAULT : Take: Crop to active take in items
 KEY 9 69 40132 0		 # Main : Cmd+E : OVERRIDE DEFAULT : Item: Open item copies in primary external editor
+KEY 1 69 40153 0		 # Main : E : OVERRIDE DEFAULT : Item: Open in built-in MIDI editor (set default behavior in preferences)
 KEY 0 59 40172 0		 # Main : ; : Markers: Go to previous marker/project start
 KEY 0 39 40173 0		 # Main : ' : OVERRIDE DEFAULT : Markers: Go to next marker/project end
 KEY 33 116 40175 0		 # Main : Control+F5 : Item properties: Toggle mute
@@ -131,19 +133,20 @@ KEY 5 76 40292 0		 # Main : Shift+L : OVERRIDE DEFAULT : Track: View envelopes f
 KEY 1 73 40293 0		 # Main : I : Track: View routing and I/O for current/last touched track
 KEY 1 118 40294 0		 # Main : F7 : OVERRIDE DEFAULT : Track: Toggle record arming for current/last touched track
 KEY 1 66 40298 0		 # Main : B : Track: Toggle FX bypass for current/last touched track
-KEY 41 88 40307 0		 # Main : Cmd+Control+X : Item: Cut selected area of items
-KEY 41 46 40312 0		 # Main : Cmd+Control+NumPad Delete : Item: Remove selected area of items
+KEY 13 88 40307 0		 # Main : Cmd+Shift+X : OVERRIDE DEFAULT : Item: Cut selected area of items
+KEY 13 32814 40312 0		 # Main : Cmd+Shift+Delete : Item: Remove selected area of items
 KEY 32 96 40315 0		 # Main : Control+` : Item: Auto trim/split items (remove silence)...
 KEY 16 91 40320 0		 # Main : Opt+[ : Time selection: Nudge left edge left
 KEY 16 93 40321 0		 # Main : Opt+] : Time selection: Nudge left edge right
 KEY 8 91 40322 0		 # Main : Cmd+[ : OVERRIDE DEFAULT : Time selection: Nudge right edge left
 KEY 8 93 40323 0		 # Main : Cmd+] : OVERRIDE DEFAULT : Time selection: Nudge right edge right
-KEY 13 32814 40333 0		 # Main : Cmd+Shift+Delete : Envelope: Delete all selected points
 KEY 17 116 40339 0		 # Main : Opt+F5 : Track: Unmute all tracks
 KEY 17 117 40340 0		 # Main : Opt+F6 : Track: Unsolo all tracks
 KEY 21 66 40344 0		 # Main : Opt+Shift+B : Track: Toggle FX bypass on all tracks
 KEY 21 77 40363 0		 # Main : Opt+Shift+M : Options: Show metronome/pre-roll settings
 KEY 13 77 40364 0		 # Main : Cmd+Shift+M : OVERRIDE DEFAULT : Options: Toggle metronome
+KEY 1 88 40396 0		 # Main : X : OVERRIDE DEFAULT : Time selection: Move contents of time selection to edit cursor (moving later items)
+KEY 1 67 40397 0		 # Main : C : OVERRIDE DEFAULT : Time selection: Copy contents of time selection to edit cursor (moving later items)
 KEY 29 86 40408 0		 # Main : Cmd+Opt+Shift+V : Track: Toggle track pre-FX volume envelope visible
 KEY 17 101 40415 0		 # Main : Opt+NumPad 5 : Envelope: Reset selected points to zero/center
 KEY 9 32805 40416 0		 # Main : Cmd+Left : OVERRIDE DEFAULT : Item navigation: Select and move to previous item
@@ -153,7 +156,7 @@ KEY 25 65 40421 0		 # Main : Cmd+Opt+A : Item: Select all items in track
 KEY 17 118 40491 0		 # Main : Opt+F7 : Track: Unarm all tracks for recording
 KEY 1 119 40495 0		 # Main : F8 : OVERRIDE DEFAULT : Track: Cycle track record monitor
 KEY 17 32813 40505 0		 # Main : Opt+Insert : Track: Select last touched track
-KEY 41 84 40508 0		 # Main : Cmd+Control+T : Item: Trim items to selected area
+KEY 13 84 40508 0		 # Main : Cmd+Shift+T : OVERRIDE DEFAULT : Item: Trim items to selected area
 KEY 25 73 40509 0		 # Main : Cmd+Opt+I : Item: Fade items in to cursor
 KEY 25 79 40510 0		 # Main : Cmd+Opt+O : Item: Fade items out from cursor
 KEY 0 64 40519 0		 # Main : @ : OVERRIDE DEFAULT : Item properties: Increase item rate by ~0.6% (10 cents)
@@ -170,7 +173,6 @@ KEY 5 86 40603 0		 # Main : Shift+V : OVERRIDE DEFAULT : Take: Paste as takes in
 KEY 1 115 40605 0		 # Main : F4 : OVERRIDE DEFAULT : Show action list
 KEY 9 76 40612 0		 # Main : Cmd+L : OVERRIDE DEFAULT : Item: Set item end to source media end
 KEY 21 82 40616 0		 # Main : Opt+Shift+R : Markers: Edit region near cursor
-KEY 1 67 40618 0		 # Main : C : OVERRIDE DEFAULT : Markers: Edit time signature marker near cursor
 KEY 0 91 40625 0		 # Main : [ : OVERRIDE DEFAULT : Time selection: Set start point
 KEY 0 93 40626 0		 # Main : ] : OVERRIDE DEFAULT : Time selection: Set end point
 KEY 1 32804 40630 0		 # Main : Home : OVERRIDE DEFAULT : Go to start of time selection
@@ -257,6 +259,7 @@ KEY 8 60 41173 0		 # Main : Cmd+< : OVERRIDE DEFAULT : Item navigation: Move cur
 KEY 9 103 41173 0		 # Main : Cmd+NumPad 7 : Item navigation: Move cursor to start of items
 KEY 8 62 41174 0		 # Main : Cmd+> : OVERRIDE DEFAULT : Item navigation: Move cursor to end of items
 KEY 9 105 41174 0		 # Main : Cmd+NumPad 9 : Item navigation: Move cursor to end of items
+KEY 5 114 41175 0		 # Main : Shift+F3 : Reset all MIDI devices
 KEY 0 47 41187 0		 # Main : / : Scrub: Toggle looped-segment scrub at edit cursor
 KEY 41 117 41199 0		 # Main : Cmd+Control+F6 : Track: Toggle track solo defeat
 KEY 25 70 41206 0		 # Main : Cmd+Opt+F : OVERRIDE DEFAULT : Item: Move and stretch items to fit time selection
@@ -272,8 +275,8 @@ KEY 32 60 41305 0		 # Main : Control+< : Item edit: Trim left edge of item to ed
 KEY 24 60 41306 0		 # Main : Cmd+Opt+< : OVERRIDE DEFAULT : Item edit: Move left edge of item to edit cursor
 KEY 24 62 41307 0		 # Main : Cmd+Opt+> : OVERRIDE DEFAULT : Item edit: Move right edge of item to edit cursor
 KEY 32 62 41311 0		 # Main : Control+> : Item edit: Trim right edge of item to edit cursor
-KEY 13 67 41383 0		 # Main : Cmd+Shift+C : OVERRIDE DEFAULT : Edit: Copy items/tracks/envelope points (depending on focus) within time selection, if any (smart copy)
-KEY 13 88 41384 0		 # Main : Cmd+Shift+X : OVERRIDE DEFAULT : Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut)
+KEY 5 67 41383 0		 # Main : Shift+C : OVERRIDE DEFAULT : Edit: Copy items/tracks/envelope points (depending on focus) within time selection, if any (smart copy)
+KEY 5 88 41384 0		 # Main : Shift+X : OVERRIDE DEFAULT : Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut)
 KEY 21 32801 41536 0		 # Main : Opt+Shift+Page Up : Transient detection sensitivity: Increase
 KEY 21 32802 41537 0		 # Main : Opt+Shift+Page Down : Transient detection sensitivity: Decrease
 KEY 33 117 41561 0		 # Main : Control+F6 : Item properties: Toggle solo exclusive
@@ -297,13 +300,14 @@ KEY 25 85 41996 0		 # Main : Cmd+Opt+U : Item: Move items to subproject (non-des
 KEY 17 85 41997 0		 # Main : Opt+U : Track: Move tracks to subproject
 KEY 13 73 42082 0		 # Main : Cmd+Shift+I : Envelope: Insert automation item
 KEY 5 73 42235 0		 # Main : Shift+I : Track: View routing and I/O for master track
+KEY 9 114 42348 0		 # Main : Cmd+F3 : Reset all MIDI control surface devices
 KEY 5 117 42455 0		 # Main : Shift+F6 : OVERRIDE DEFAULT : FX: Toggle delta solo for last focused FX
 KEY 13 78 42460 0		 # Main : Cmd+Shift+N : OVERRIDE DEFAULT : Item properties: Normalize items (peak/RMS/LUFS)...
 KEY 21 117 42467 0		 # Main : Opt+Shift+F6 : FX: Clear delta solo for all project FX
 KEY 255 3048 65535 0		 # Main :  : No-op (no action)
 KEY 255 3304 65535 0		 # Main :  : No-op (no action)
 KEY 255 248 990 0		 # Main : Mousewheel : OVERRIDE DEFAULT : View: Zoom horizontally (MIDI CC relative/mousewheel)
-KEY 33 40 _0560a0aa82a4473b9a964e7de01e588f 0		 # Main : Control+NumPad Down : Custom: Solo exclusive next track
+KEY 33 32802 _0560a0aa82a4473b9a964e7de01e588f 0		 # Main : Control+Page Down : Custom: Solo exclusive next track
 KEY 40 46 _0e77201d60c10d4d844fe05ac22623e1 0		 # Main : Cmd+Control+. : Custom: trim right edge of items respecting ripple
 KEY 8 61 _6147697fe03f864580dc8b7ff1efc0b1 0		 # Main : Cmd+= : Custom: fast forward
 KEY 21 73 _687988e0f1d862478b1407f864d3fd6b 0		 # Main : Opt+Shift+I : Custom: add stretch marker to cursor and snap to grid
@@ -337,7 +341,7 @@ KEY 5 80 _OSARA_FXPARAMSMASTER 0		 # Main : Shift+P : OSARA: View FX parameters 
 KEY 25 36 _OSARA_GOTOFIRSTTRACK 0		 # Main : Cmd+Opt+NumPad Home : OSARA: Go to first track
 KEY 25 35 _OSARA_GOTOLASTTRACK 0		 # Main : Cmd+Opt+NumPad End : OSARA: Go to last track
 KEY 29 32804 _OSARA_GOTOMASTERTRACK 0		 # Main : Cmd+Opt+Shift+Home : OSARA: Go to master track
-KEY 5 67 _OSARA_MANAGETEMPOTIMESIGMARKERS 0		 # Main : Shift+C : OVERRIDE DEFAULT : OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers
+KEY 1 79 _OSARA_MANAGETEMPOTIMESIGMARKERS 0		 # Main : O : OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers
 KEY 25 77 _OSARA_MOVESTRETCH 0		 # Main : Cmd+Opt+M : OVERRIDE DEFAULT : OSARA: Move last focused stretch marker to current edit cursor position
 KEY 17 75 _OSARA_NEXTENVPOINT 0		 # Main : Opt+K : OSARA: Move to next envelope point
 KEY 21 75 _OSARA_NEXTENVPOINTKEEPSEL 0		 # Main : Opt+Shift+K : OSARA: Move to next envelope point (leaving other points selected)
@@ -383,8 +387,7 @@ KEY 29 80 _OSARA_TOGGLEPREFXPANTAKEPITCHENVELOPE 0		 # Main : Cmd+Opt+Shift+P : 
 KEY 5 32 _OSARA_TOGGLESEL 0		 # Main : Shift+Space : OSARA: Enable noncontiguous selection/toggle selection of current track/item (depending on focus)
 KEY 25 86 _OSARA_TOGGLEVOLUMEENVELOPE 0		 # Main : Cmd+Opt+V : OVERRIDE DEFAULT : OSARA: Toggle track/take volume envelope visibility (depending on focus)
 KEY 17 119 _OSARA_UNMONITORALLTRACKS 0		 # Main : Opt+F8 : OSARA: Unmonitor all tracks
-KEY 1 79 _PADRE_ENVLFO 0		 # Main : O : SWS/PADRE: Envelope LFO generator
-KEY 1 69 _PADRE_ENVPROC 0		 # Main : E : OVERRIDE DEFAULT : SWS/PADRE: Envelope processor
+KEY 25 69 _PADRE_ENVPROC 0		 # Main : Cmd+Opt+E : OVERRIDE DEFAULT : SWS/PADRE: Envelope processor
 KEY 29 34 _S&M_MOVE_FX_DOWN 0		 # Main : Cmd+Opt+Shift+NumPad Page Down : SWS/S&M: Move selected FX down in chain for selected tracks
 KEY 29 33 _S&M_MOVE_FX_UP 0		 # Main : Cmd+Opt+Shift+NumPad Page Up : SWS/S&M: Move selected FX up in chain for selected tracks
 KEY 1 81 _S&M_SENDS4 0		 # Main : Q : SWS/S&M: Open/close Cue Buss generator
@@ -447,7 +450,7 @@ KEY 17 83 _XENAKIOS_SETPANVOLSELTAKES 0		 # Main : Opt+S : OVERRIDE DEFAULT : Xe
 KEY 0 96 _XENAKIOS_SHOW_COMMANDPARAMS 0		 # Main : ` : OVERRIDE DEFAULT : Xenakios/SWS: Command parameters
 KEY 25 32 _XENAKIOS_TIMERTEST1 0		 # Main : Cmd+Opt+Space : Xenakios/SWS: Play selected items once
 KEY 9 75 _a77ae1752661af4bb75a473af340ff6a 0		 # Main : Cmd+K : Custom: Move to item peak and report the position
-KEY 33 38 _ce078dd0845b44aebcc49334dfa669c6 0		 # Main : Control+NumPad Up : Custom: Solo exclusive previous track
+KEY 33 32801 _ce078dd0845b44aebcc49334dfa669c6 0		 # Main : Control+Page Up : Custom: Solo exclusive previous track
 KEY 40 44 _e85f8b38153399499e2e176a8bcec06c 0		 # Main : Cmd+Control+, : Custom: trim left edge of items respecting ripple
 KEY 1 65 _eee7137cb72ad2489abf82cde9121025 0		 # Main : A : Custom: Select and split item under edit or play cursor
 KEY 25 75 _f763830b0c370543958ed63fb1310299 0		 # Main : Cmd+Opt+K : Custom: insert/edit tempo marker and add stretch marker at cursor
@@ -461,6 +464,7 @@ KEY 5 123 1 102		 # glob hotkey : Shift+F12 :
 KEY 0 63 0 32060		 # MIDI Editor : ? : DISABLED DEFAULT
 KEY 13 32805 0 32060		 # MIDI Editor : Cmd+Shift+Left : DISABLED DEFAULT
 KEY 13 32807 0 32060		 # MIDI Editor : Cmd+Shift+Right : DISABLED DEFAULT
+KEY 13 88 0 32060		 # MIDI Editor : Cmd+Shift+X : DISABLED DEFAULT
 KEY 29 32806 0 32060		 # MIDI Editor : Cmd+Opt+Shift+Up : DISABLED DEFAULT
 KEY 29 32808 0 32060		 # MIDI Editor : Cmd+Opt+Shift+Down : DISABLED DEFAULT
 KEY 9 101 0 32060		 # MIDI Editor : Cmd+NumPad 5 : DISABLED DEFAULT
@@ -469,6 +473,9 @@ KEY 9 90 0 32060		 # MIDI Editor : Cmd+Z : DISABLED DEFAULT
 KEY 0 95 1011 32060		 # MIDI Editor : _ : View: Zoom out horizontally
 KEY 9 82 1139 32060		 # MIDI Editor : Cmd+R : Transport: Toggle repeat
 KEY 9 115 2 32060		 # MIDI Editor : Cmd+F4 : File: Close window
+KEY 25 65 40003 32060		 # MIDI Editor : Cmd+Opt+A : Edit: Select all notes
+KEY 1 13 40004 32060		 # MIDI Editor : Return : Edit: Event properties
+KEY 9 113 40004 32060		 # MIDI Editor : Cmd+F2 : OVERRIDE DEFAULT : Edit: Event properties
 KEY 1 32 40016 32060		 # MIDI Editor : Space : OVERRIDE DEFAULT : Transport: Play/stop
 KEY 33 32 40017 32060		 # MIDI Editor : Control+Space : Transport: Play/pause
 KEY 9 32804 40036 32060		 # MIDI Editor : Cmd+Home : View: Go to start of file
@@ -565,12 +572,19 @@ KEY 5 86 40464 32060		 # MIDI Editor : Shift+V : Edit: Note velocity -01
 KEY 17 103 40465 32060		 # MIDI Editor : Opt+NumPad 7 : Edit: Note velocity -10
 KEY 21 86 40465 32060		 # MIDI Editor : Opt+Shift+V : Edit: Note velocity -10
 KEY 37 81 40469 32060		 # MIDI Editor : Shift+Control+Q : Quantize notes position to grid
+KEY 17 73 40501 32060		 # MIDI Editor : Opt+I : Invert selection
 KEY 13 76 40633 32060		 # MIDI Editor : Cmd+Shift+L : Edit: Set note lengths to grid size
 KEY 13 32803 40639 32060		 # MIDI Editor : Cmd+Shift+End : Navigate: Move edit cursor to end of selected events
 KEY 1 67 40664 32060		 # MIDI Editor : C : Edit: Toggle selection of all CC events under selected notes
+KEY 25 67 40668 32060		 # MIDI Editor : Cmd+Opt+C : Select all CC events in last clicked lane
+KEY 25 85 40669 32060		 # MIDI Editor : Cmd+Opt+U : Unselect all CC events in last clicked lane
 KEY 0 61 40676 32060		 # MIDI Editor : = : OVERRIDE DEFAULT : Edit: Increase value a little bit for CC events
 KEY 0 45 40677 32060		 # MIDI Editor : - : OVERRIDE DEFAULT : Edit: Decrease value a little bit for CC events
 KEY 13 80 40729 32060		 # MIDI Editor : Cmd+Shift+P : Quantize notes position and end to grid
+KEY 5 67 40733 32060		 # MIDI Editor : Shift+C : Edit: Copy events within time selection, if any (smart copy)
+KEY 5 88 40734 32060		 # MIDI Editor : Shift+X : Edit: Cut events within time selection, if any (smart cut)
+KEY 13 67 40747 32060		 # MIDI Editor : Cmd+Shift+C : OVERRIDE DEFAULT : Edit: Select all CC events in time selection (in last clicked CC lane)
+KEY 29 67 40751 32060		 # MIDI Editor : Cmd+Opt+Shift+C : Edit: Select all CC events in time selection (even if CC lane is hidden)
 KEY 25 70 40754 32060		 # MIDI Editor : Cmd+Opt+F : Edit: Fit notes to time selection
 KEY 1 71 40765 32060		 # MIDI Editor : G : Edit: Make notes legato, preserving note start times
 KEY 9 32808 40835 32060		 # MIDI Editor : Cmd+Down : OVERRIDE DEFAULT : Activate next MIDI track
@@ -591,6 +605,7 @@ KEY 9 49 41081 32060		 # MIDI Editor : Cmd+1 : Set length for next inserted note
 KEY 9 8 41295 32060		 # MIDI Editor : Cmd+Backspace : Set length for next inserted note: grid
 KEY 8 46 41712 32060		 # MIDI Editor : Cmd+. : Set length for next inserted note: dotted preserving division length
 KEY 9 84 41713 32060		 # MIDI Editor : Cmd+T : Set length for next inserted note: triplet preserving division length
+KEY 9 73 42469 32060		 # MIDI Editor : Cmd+I : OVERRIDE DEFAULT : Edit: Insert CC event at edit cursor in current lane
 KEY 5 81 _53b7b74114d130409a9fd4d31c97ebe4 32060		 # MIDI Editor : Shift+Q : Custom: Select and quantize notes position to grid
 KEY 1 101 _720c5c7f27504a868a0360b323eca963 32060		 # MIDI Editor : NumPad 5 : Custom: Insert note, maintaining current position of edit cursor
 KEY 1 73 _720c5c7f27504a868a0360b323eca963 32060		 # MIDI Editor : I : OVERRIDE DEFAULT : Custom: Insert note, maintaining current position of edit cursor


### PR DESCRIPTION
An older version was accidentally included in the prior snapshot.