### PR TITLE
Improve feedback stretch markers

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3835,11 +3835,13 @@ void cmdhAddOrRemoveStretch(int command) {
 	int difference = newCount - oldCount;
 	if (newCount >= oldCount) {
 		if (shouldReportTimeMovement()) {
+		// Translators: Reported when one or more stretch markers are added. {} will be replaced by the number of stretch markers, EG "2 stretch markers added".
 			outputMessage(format(
 				translate_plural("{} stretch marker added", "{} stretch markers added", difference),
 				difference));
 		}
 	} else {
+		// Translators: Reported when one or more stretch markers are removed. {} will be replaced by the number of stretch markers, EG "2 stretch markers removed".
 		outputMessage(format(
 			translate_plural("{} stretch marker removed", "{} stretch markers removed", -difference),
 			-difference));

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3809,17 +3809,45 @@ void cmdDeleteTimeSig(Command* command) {
 		outputMessage(translate("time signature deleted"));
 }
 
-void cmdRemoveStretch(Command* command) {
-	MediaItem* item = GetSelectedMediaItem(0, 0);
-	if (!item)
+void cmdhAddOrRemoveStretch(int command) {
+	const int itemCount = CountSelectedMediaItems(nullptr);
+	if (itemCount == 0) {
+		outputMessage(translate("no selected items"));
 		return;
-	MediaItem_Take* take = GetActiveTake(item);
-	if (!take)
-		return;
-	int count = GetTakeNumStretchMarkers(take);
-	Main_OnCommand(41859, 0); // Item: remove stretch marker at current position
-	if (GetTakeNumStretchMarkers(take) != count)
-		outputMessage(translate("stretch marker deleted"));
+	}
+	int oldCount = 0;
+	for (int i = 0; i < itemCount; ++i) {
+		MediaItem* item = GetSelectedMediaItem(nullptr, i);
+		MediaItem_Take* take = GetActiveTake(item);
+		if (!take)
+			continue;
+		oldCount += GetTakeNumStretchMarkers(take);
+	}
+	Main_OnCommand(command, 0);
+	int newCount = 0;
+	for (int i = 0; i < itemCount; ++i) {
+		MediaItem* item = GetSelectedMediaItem(nullptr, i);
+		MediaItem_Take* take = GetActiveTake(item);
+		if (!take)
+			continue;
+		newCount += GetTakeNumStretchMarkers(take);
+	}
+	int difference = newCount - oldCount;
+	if (newCount >= oldCount) {
+		if (shouldReportTimeMovement()) {
+			outputMessage(format(
+				translate_plural("{} stretch marker added", "{} stretch markers added", difference),
+				difference));
+		}
+	} else {
+		outputMessage(format(
+			translate_plural("{} stretch marker removed", "{} stretch markers removed", -difference),
+			-difference));
+	}
+}
+
+void cmdAddOrRemoveStretch(Command* command) {
+	cmdhAddOrRemoveStretch(command->gaccel.accel.cmd);
 }
 
 void cmdClearTimeLoopSel(Command* command) {
@@ -4273,6 +4301,7 @@ void cmdRemoveFocus(Command* command) {
 			cmdhRemoveItems(40006); // Item: Remove items
 			break;
 		case FOCUS_MARKER:
+		
 			cmdDeleteMarker(nullptr);
 			break;
 		case FOCUS_REGION:
@@ -4282,7 +4311,7 @@ void cmdRemoveFocus(Command* command) {
 			cmdDeleteTimeSig(nullptr);
 			break;
 		case FOCUS_STRETCH:
-			cmdRemoveStretch(nullptr);
+			cmdhAddOrRemoveStretch(41859);
 			break;
 		case FOCUS_ENVELOPE:
 			cmdhDeleteEnvelopePointsOrAutoItems(40333, true, false); // Envelope: Delete all selected points
@@ -5107,7 +5136,10 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 40613}, nullptr}, nullptr, cmdDeleteMarker}, // Markers: Delete marker near cursor
 	{MAIN_SECTION, {{0, 0, 40615}, nullptr}, nullptr, cmdDeleteRegion}, // Markers: Delete region near cursor
 	{MAIN_SECTION, {{0, 0, 40617}, nullptr}, nullptr, cmdDeleteTimeSig}, // Markers: Delete time signature marker near cursor
-	{MAIN_SECTION, {{0, 0, 41859}, nullptr}, nullptr, cmdRemoveStretch}, // Item: remove stretch marker at current position
+	{MAIN_SECTION, {{0, 0, 41842}, nullptr}, nullptr, cmdAddOrRemoveStretch}, // Item: Add stretch marker at cursor
+	{MAIN_SECTION, {{0, 0, 41859}, nullptr}, nullptr, cmdAddOrRemoveStretch}, // Item: remove stretch marker at current position
+	{MAIN_SECTION, {{0, 0, 41844}, nullptr}, nullptr, cmdAddOrRemoveStretch}, // Item: Remove all stretch markers
+	{MAIN_SECTION, {{0, 0, 41845}, nullptr}, nullptr, cmdAddOrRemoveStretch}, // Item: Remove all stretch markers in time selection
 	{MAIN_SECTION, {{0, 0, 40020}, nullptr}, nullptr, cmdClearTimeLoopSel}, // Time selection: Remove time selection and loop point selection
 	{MAIN_SECTION, {{0, 0, 40769}, nullptr}, nullptr, cmdUnselAllTracksItemsPoints}, // Unselect all tracks/items/envelope points
 	{MAIN_SECTION, {{0, 0, 40915}, nullptr}, nullptr, cmdInsertEnvelopePoint}, // Envelope: Insert new point at current position (remove nearby points)


### PR DESCRIPTION
Make OSARA report the addition of stretch markers when Report time movement during playback/recording is enabled in Config. Requested on RWP.