### PR TITLE
Report cycle edit mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -890,6 +890,7 @@ This list is worth referencing when making your own key map additions, assigning
 - Markers: Delete region near cursor
 - New project tab (ignore default template)
 - Options: Envelope points move with media items
+- Options: Cycle through editing modes: Auto-crossfade off, auto-crossfade on, trim content behind media items
 - Tempo: Decrease current project tempo 0.1 BPM
 - Tempo: Decrease current project tempo 10 BPM
 - Tempo: Decrease current project tempo 10 percent

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1571,6 +1571,18 @@ void maybeAddRippleMessage(ostringstream& s, int command) {
 	}
 }
 
+void postCycleEditMode(int command) {
+	if (GetToggleCommandState(40041) && GetToggleCommandState (41117)) {
+		outputMessage(translate("crossfade on trimming on"));
+	}else if (GetToggleCommandState(40041)) {
+		outputMessage(translate("crossfade on trimming off"));
+	} else if (GetToggleCommandState (41117)) {
+		outputMessage(translate("crossfade off trimming on"));
+	} else {
+		outputMessage(translate("crossfade off trimming off"));
+	}
+}
+
 void reportRepeat(bool repeat) {
 	outputMessage(repeat ?
 		translate("repeat on") :
@@ -2503,6 +2515,7 @@ PostCommand POST_COMMANDS[] = {
 	{40283, postChangeTrackPan}, // Track: Nudge track pan left
 	{40284, postChangeTrackPan}, // Track: Nudge track pan right
 	{1155, postCycleRippleMode}, // Options: Cycle ripple editing mode
+	{41116, postCycleEditMode}, // Options: Cycle through editing modes: Auto-crossfade off, auto-crossfade on, trim content behind media items
 	{1068, postToggleRepeat}, // Transport: Toggle repeat
 	{40125, postSwitchToTake}, // Take: Switch items to next take
 	{40126, postSwitchToTake}, // Take: Switch items to previous take

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1573,13 +1573,13 @@ void maybeAddRippleMessage(ostringstream& s, int command) {
 
 void postCycleEditMode(int command) {
 	if (GetToggleCommandState(40041) && GetToggleCommandState (41117)) {
-		outputMessage(translate("crossfade on trimming on"));
+		outputMessage(translate("enabled auto crossfading and trim"));
 	}else if (GetToggleCommandState(40041)) {
-		outputMessage(translate("crossfade on trimming off"));
+		outputMessage(translate("crossfading, not trimming"));
 	} else if (GetToggleCommandState (41117)) {
-		outputMessage(translate("crossfade off trimming on"));
+		outputMessage(translate("trimming, not crossfading"));
 	} else {
-		outputMessage(translate("crossfade off trimming off"));
+		outputMessage(translate("disabled auto crossfades and trim"));
 	}
 }
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1573,12 +1573,16 @@ void maybeAddRippleMessage(ostringstream& s, int command) {
 
 void postCycleEditMode(int command) {
 	if (GetToggleCommandState(40041) && GetToggleCommandState (41117)) {
-		outputMessage(translate("enabled auto crossfading and trim"));
+		// Translators: Reported when auto crossfade and trim content behind media items are both enabled.
+		outputMessage(translate("enabled auto crossfades and trim"));
 	}else if (GetToggleCommandState(40041)) {
+		// Translators: Reported when auto crossfade is enabled, trim behind media items is disabled.  
 		outputMessage(translate("crossfading, not trimming"));
 	} else if (GetToggleCommandState (41117)) {
+		// Translators: Reported when trim content behind media items is enabled, auto crossfade is disabled.
 		outputMessage(translate("trimming, not crossfading"));
 	} else {
+		// Translators: Reported when auto crosfade and trim content behind media items are both disabled.
 		outputMessage(translate("disabled auto crossfades and trim"));
 	}
 }


### PR DESCRIPTION
Added speech feedback for Options: Cycle through editing modes: Auto-crossfade off, auto-crossfade on, trim content behind media items, requested on RWP.
this is an unusual cycle action with four steps which modify the states of crossfading and trimming content behind items.
Initially I implemented standard osara reporting style like crossfade on, trim off, but testing in situ it was hard to keep track of the combinations as I cycled, so instead I've added reports that separate the two settings being changed, with the start of each report being unique.
Overall, I'm aiming for lower cognitive load and faster recognition of each step in the cycle.
