### PR TITLE
Add report project length action

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -828,7 +828,8 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: Report length of last touched item
 - OSARA: Report regions, last project marker and items on selected tracks at current position: Control+Shift+R
  - Pressing this twice will display the information in a dialog with a text box for easy review.
-- OSARA: About: Control+F1
+- OSARA: Report project length
+- OSARA: About: Control+F1 (use this dialog when you need to check the date of the snapshot you're running)
 
 #### Midi Editor section of actions list
 - OSARA: Move to next midi item on track: Control+RightArrow

--- a/src/osara.h
+++ b/src/osara.h
@@ -98,6 +98,7 @@
 #define REAPERAPI_WANT_SetTakeStretchMarker
 #define REAPERAPI_WANT_ValidatePtr
 #define REAPERAPI_WANT_DeleteTempoTimeSigMarker
+#define REAPERAPI_WANT_GetProjectLength
 #define REAPERAPI_WANT_MIDIEditor_GetActive
 #define REAPERAPI_WANT_MIDIEditor_GetTake
 #define REAPERAPI_WANT_MIDIEditor_GetSetting_str
@@ -329,7 +330,7 @@ std::string formatTime(double time, TimeFormat format=TF_RULER,
 	bool includeZeros=true, bool includeProjectStartOffset=true);
 void resetTimeCache(TimeFormat excludeFormat=TF_NONE);
 std::string formatLength(double start, double end, TimeFormat format=TF_RULER,
-	FormatTimeCacheRequest cache=FT_NO_CACHE, bool includeZeros=true);
+	FormatTimeCacheRequest cache=FT_NO_CACHE, bool includeZeros=true, bool includeProjectStartOffset=false);
 std::string formatNoteLength(double start, double end);
 std::string formatCursorPosition(TimeFormat format=TF_RULER,
 	FormatTimeCacheRequest cache=FT_CACHE_DEFAULT);

--- a/src/osara.h
+++ b/src/osara.h
@@ -330,7 +330,7 @@ std::string formatTime(double time, TimeFormat format=TF_RULER,
 	bool includeZeros=true, bool includeProjectStartOffset=true);
 void resetTimeCache(TimeFormat excludeFormat=TF_NONE);
 std::string formatLength(double start, double end, TimeFormat format=TF_RULER,
-	FormatTimeCacheRequest cache=FT_NO_CACHE, bool includeZeros=true, bool includeProjectStartOffset=false);
+	FormatTimeCacheRequest cache=FT_NO_CACHE, bool includeZeros=true);
 std::string formatNoteLength(double start, double end);
 std::string formatCursorPosition(TimeFormat format=TF_RULER,
 	FormatTimeCacheRequest cache=FT_CACHE_DEFAULT);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -449,12 +449,12 @@ string formatNoteLength(double start, double end) {
 }
 
 string formatLength(double start, double end, TimeFormat timeFormat,
-	FormatTimeCacheRequest cache, bool includeZeros) {
+	FormatTimeCacheRequest cache, bool includeZeros, bool includeProjectStartOffset) {
 	timeFormat = getTimeFormat(timeFormat);
 	if(timeFormat != TF_MEASURE && timeFormat != TF_MEASURETICK) {
 		// In all other cases, position and length reports are the same, so
 		// formatTime can handle them.
-		return formatTime(end - start, timeFormat, cache, includeZeros, false);
+		return formatTime(end - start, timeFormat, cache, includeZeros, includeProjectStartOffset);
 	}
 	int startMeasure, startMeasureLength, timeDenom, endMeasure, endMeasureLength;
 	double startBeat = TimeMap2_timeToBeats(nullptr, start, &startMeasure,
@@ -485,7 +485,7 @@ string formatLength(double start, double end, TimeFormat timeFormat,
 	}
 	return formatTimeMeasure(measures, beats, measureLength, timeDenom,
 		timeFormat == TF_MEASURETICK, true, cache == FT_USE_CACHE, includeZeros,
-		false);
+		includeProjectStartOffset);
 } 
 
 string formatCursorPosition(TimeFormat format, FormatTimeCacheRequest cache) {
@@ -4528,6 +4528,28 @@ void cmdReportItemLength(Command* command) {
 	outputMessage(formatLength(start, end, TF_RULER, FT_NO_CACHE, false));
 }
 
+void cmdReportProjectLength(Command* command) {
+	TimeFormat tf;
+	if (lastCommandRepeatCount == 0) {
+		// Use primary ruler unit.
+		tf = TF_RULER;
+	} else if (GetToggleCommandState(42361)) {
+		tf = TF_MINSEC;
+	} else if (GetToggleCommandState(42362)) {
+		tf = TF_SEC;
+	} else if (GetToggleCommandState(42363)) {
+		tf = TF_SAMPLE;
+	} else if (GetToggleCommandState(42364)) {
+		tf = TF_HMSF;
+	} else if (GetToggleCommandState(42365)) {
+		tf = TF_FRAME;
+	} else {
+		tf = TF_RULER;
+	}
+	double end = GetProjectLength(nullptr);
+	outputMessage(formatLength(0, end, tf, FT_NO_CACHE, false, false));
+}
+
 void reportCursorPositionPrimaryFormat() {
 	// This function can be called when only reporting the primary ruler format is needed.
 	TimeFormat tf = TF_RULER;
@@ -5291,6 +5313,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Toggle shortcut help")}, "OSARA_SHORTCUTHELP", cmdShortcutHelp},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report edit/play cursor position, transport state and nearest markers and regions")}, "OSARA_CURSORPOS", cmdReportCursorPosition},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report length of last touched item")}, "OSARA_REPORTLENGTHSELITEM", cmdReportItemLength},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report project length")}, "OSARA_REPORTPROJLENGTH", cmdReportProjectLength},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current track/item (depending on focus)")}, "OSARA_TOGGLESEL", cmdToggleSelection},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Move last focused stretch marker to current edit cursor position")}, "OSARA_MOVESTRETCH", cmdMoveStretch},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report level in peak dB at play cursor for channel 1 of current track (reports input level instead when track is armed)")}, "OSARA_REPORTPEAKCURRENTC1", cmdReportPeakCurrentC1},

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -849,6 +849,29 @@ string gridDivisionToFriendlyName(double division) {
 	return translate("grid  unknown");
 }
 
+TimeFormat getPrimaryOrSecondaryTimeFormatForCommand() {
+	TimeFormat tf;
+	if (lastCommandRepeatCount == 0) {
+		// Use primary ruler unit.
+		tf = TF_RULER;
+	} else if (GetToggleCommandState(42361)) {
+		tf = TF_MINSEC;
+	} else if (GetToggleCommandState(42362)) {
+		tf = TF_SEC;
+	} else if (GetToggleCommandState(42363)) {
+		tf = TF_SAMPLE;
+	} else if (GetToggleCommandState(42364)) {
+		tf = TF_HMSF;
+	} else if (GetToggleCommandState(42365)) {
+		tf = TF_FRAME;
+	} else {
+		tf = TF_RULER;
+	}
+	return tf;
+}
+
+// End of utility/helper functions
+
 // Functions exported from SWS
 const char* (*NF_GetSWSTrackNotes)(MediaTrack* track) = nullptr;
 
@@ -4377,23 +4400,7 @@ void cmdShortcutHelp(Command* command) {
 }
 
 void cmdReportCursorPosition(Command* command) {
-	TimeFormat tf;
-	if (lastCommandRepeatCount == 0) {
-		// Use primary ruler unit.
-		tf = TF_RULER;
-	} else if (GetToggleCommandState(42361)) {
-		tf = TF_MINSEC;
-	} else if (GetToggleCommandState(42362)) {
-		tf = TF_SEC;
-	} else if (GetToggleCommandState(42363)) {
-		tf = TF_SAMPLE;
-	} else if (GetToggleCommandState(42364)) {
-		tf = TF_HMSF;
-	} else if (GetToggleCommandState(42365)) {
-		tf = TF_FRAME;
-	} else {
-		tf = TF_RULER;
-	}
+	TimeFormat tf = getPrimaryOrSecondaryTimeFormatForCommand();
 	int state = GetPlayState();
 	double pos = state & 1 ? GetPlayPosition() : GetCursorPosition();
 	ostringstream s;
@@ -4529,29 +4536,13 @@ void cmdReportItemLength(Command* command) {
 }
 
 void cmdReportProjectLength(Command* command) {
-	TimeFormat tf;
-	if (lastCommandRepeatCount == 0) {
-		// Use primary ruler unit.
-		tf = TF_RULER;
-	} else if (GetToggleCommandState(42361)) {
-		tf = TF_MINSEC;
-	} else if (GetToggleCommandState(42362)) {
-		tf = TF_SEC;
-	} else if (GetToggleCommandState(42363)) {
-		tf = TF_SAMPLE;
-	} else if (GetToggleCommandState(42364)) {
-		tf = TF_HMSF;
-	} else if (GetToggleCommandState(42365)) {
-		tf = TF_FRAME;
-	} else {
-		tf = TF_RULER;
-	}
+	TimeFormat tf = getPrimaryOrSecondaryTimeFormatForCommand();
 	double end = GetProjectLength(nullptr);
 	outputMessage(formatLength(0, end, tf, FT_NO_CACHE, false, false));
 }
 
 void reportCursorPositionPrimaryFormat() {
-	// This function can be called when only reporting the primary ruler format is needed.
+	// Call when you only want to report the primary ruler format, EG moving through transients, where fast key presses should continue to report info in a single format.
 	TimeFormat tf = TF_RULER;
 	int state = GetPlayState();
 	double pos = state & 1 ? GetPlayPosition() : GetCursorPosition();


### PR DESCRIPTION
Added "OSARA: Report project length" action which was requested on RWP, unmapped at the moment. Calling once reports primary ruler format, calling twice quickly reports secondary. Note that during implementation we added an extra parameter to formatLength function in order to support REAPER's project start time offset feature, but it turned out that REAPER itself doesn't respect that when rendering yet. There were circumstances where OSARA would report a different project length to a render with Bounds set to Entire project, so for now I'm not using the extra param because it lead to a confusing UX. The code is still included though, it will be useful when Cockos improve the render behaviour. When that happens, change the last argument to true when calling formatLength.