### PR TITLE
build: Suppress compiler complaints when including simpleson/json.h.

### DIFF
--- a/src/updateCheck.cpp
+++ b/src/updateCheck.cpp
@@ -8,7 +8,11 @@
 #include <ctime>
 #include <string>
 #include <sstream>
+// simpleson uses sscanf. We don't have any control over that.
+#pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <simpleson/json.h>
+#pragma clang diagnostic pop
 // osara.h includes windows.h, which must be included before other Windows
 // headers.
 #include "osara.h"


### PR DESCRIPTION
Without this, building fails on recent versions of Visual Studio. json.h uses sscanf, which seems to bother recent versions of Visual Studio even though it wasn't an issue previously.