### PR TITLE
Don't try to use UIA before we've even tried to initialize it.

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -352,6 +352,7 @@ extern IAccPropServices* accPropServices;
 
 // uia.cpp
 bool initializeUia();
+bool hasTriedToInitializeUia();
 bool terminateUia();
 bool shouldUseUiaNotifications();
 bool sendUiaNotification(const std::string& message, bool interrupt = true);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -93,6 +93,12 @@ string narrow(const wstring& text) {
 string lastMessage;
 HWND lastMessageHwnd = nullptr;
 void _outputMessage(const string& message, bool interrupt) {
+	if (!hasTriedToInitializeUia()) {
+		// #1173: This is very early in startup and we haven't called initializeUia()
+		// yet. We can't call it now, but we also don't want to fall back to MSAA.
+		// A message this early isn't useful anyway, so just ignore it.
+		return;
+	}
 	if (shouldUseUiaNotifications()) {
 		if (sendUiaNotification(message, interrupt)) {
 			return;

--- a/src/uia.cpp
+++ b/src/uia.cpp
@@ -159,9 +159,11 @@ WNDCLASSEX getWindowClass() {
 	return windowClass;
 }
 
+bool hasTriedToInitialize = false;
 WNDCLASSEX windowClass;
 
 bool initializeUia() {
+	hasTriedToInitialize = true;
 	uiaCore = make_unique<UiaCore>();
 	// If UiaRaiseNotificationEvent is available, UiaDisconnectProvider and
 	// UiaDisconnectAllProviders will also be available, so we don't need to
@@ -198,6 +200,10 @@ bool initializeUia() {
 	// takes it to 1.
 	uiaProvider = new UiaProvider(uiaWnd);
 	return true;
+}
+
+bool hasTriedToInitializeUia() {
+	return hasTriedToInitialize;
 }
 
 bool terminateUia() {


### PR DESCRIPTION
REAPER can sometimes cause OSARA to report a message very early in startup before we've tried to initialize UIA. When this happened, we previously fell back to MSAA for the entire session. This broke OSARA's ability to interrupt messages and report when a ListView is focused, among other things. To fix this, if we haven't tried to initialize UIA yet, just ignore the message. A message this early isn't useful anyway.

Fixes #1173.