### PR TITLE
Add feedback for MIDI event mute/unmute

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -998,11 +998,12 @@ vector<MidiControlChange> getSelectedCCs(MediaItem_Take* take, int offset=-1) {
 		if (ccIndex == -1) {
 			break;
 		}
+		bool muted;
 		double position;
 		int chan, msg1, msg2, msg3;
-		MIDI_GetCC(take, ccIndex, nullptr, nullptr, &position, &msg1, &chan, &msg2, &msg3);
+		MIDI_GetCC(take, ccIndex, nullptr, &muted, &position, &msg1, &chan, &msg2, &msg3);
 		position = MIDI_GetProjTimeFromPPQPos(take, position);
-		ccs.push_back({chan, ccIndex, msg1, msg2, msg3, position});
+		ccs.push_back({chan, ccIndex, msg1, msg2, msg3, position, true, muted});
 	}
 	return ccs;
 }
@@ -2341,7 +2342,7 @@ void postMidiToggleMute(int command) {
 	} else if (noteCount == 0) { // If only CCs are selected
 		fakeFocus = FOCUS_CC;
 		if (CCCount == 1) {
-			auto cc = findCC(take, 0);
+			auto cc = selectedCCs[0];
 			if (cc.muted)
 			s << translate("muted") << " ";
 			s << describeCC(take, cc);

--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -2325,6 +2325,8 @@ void postMidiToggleMute(int command) {
 			if (noteCount == 1) {
 				if (selectedNotes[0].muted)
 				s << translate("muted") << " ";
+				else
+				s << translate("unmuted") << " ";
 				s << getMidiNoteName(take, selectedNotes[0].pitch, selectedNotes[0].channel);
 			} else {
 				// Translators: used when reporting the number of notes.
@@ -2345,6 +2347,8 @@ void postMidiToggleMute(int command) {
 			auto cc = selectedCCs[0];
 			if (cc.muted)
 			s << translate("muted") << " ";
+			else
+			s << translate("unmuted") << " ";
 			s << describeCC(take, cc);
 		} else {
 			// Translators: used when reporting the number of CCs.

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -69,6 +69,7 @@ void postMidiChangeCCValue(int command);
 void postMidiSwitchCCLane(int command);
 void postToggleMidiInputsAsStepInput(int command);
 void postToggleFunctionKeysAsStepInput(int command);
+void postMidiToggleMute(int command);
 void postMidiToggleSnap(int command);
 void postMidiChangeZoom(int command);
 int countSelectedEvents(MediaItem_Take* take);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2722,6 +2722,7 @@ MidiPostCommand MIDI_POST_COMMANDS[] = {
 	{40010, postMidiCopyEvents, true}, // Edit: Copy
 	{40049, postMidiMovePitchCursor}, // Edit: Increase pitch cursor one semitone
 	{40050, postMidiMovePitchCursor}, // Edit: Decrease pitch cursor one semitone
+	{40055, postMidiToggleMute, true}, // Edit: Mute events (toggle)
 	{40177, postMidiChangePitch, true, true}, // Edit: Move notes up one semitone
 	{40178, postMidiChangePitch, true, true}, // Edit: Move notes down one semitone
 	{40179, postMidiChangePitch, true, true}, // Edit: Move notes up one octave


### PR DESCRIPTION
I wanted to add feedback when muting/unmuting MIDI events. The reported message should depend on the selection (notes vs CCs vs both). The basic logic seems to work, but I can't figure out how to count muted CCs, because a method completely analogous to how it's done with notes is clearly not possible - at least that's my impression.
@jcsteh could you take a look and perhaps even fix the problem? I think it would take far less time for you to fix it than explain to me what the problem is, but of course I'm not opposed to fixing it myself - I just don't know how.
Many thanks...