### PR TITLE
Improve feedback for Item: Copy loop of selected area of audio items,…

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3753,9 +3753,8 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 	// the command might show an error, so we need to avoid speaking if the focus changes
 	HWND oldFocus = GetFocus();
 	bool focusChanged = false;
-	auto guard = make_shared<bool>(true); // guard against the lambda accessing out of scope variables
-	auto later = CallLater([&focusChanged, &oldFocus, guard] {
-		if(*guard && GetFocus() != oldFocus) {
+	auto later = CallLater([&focusChanged, &oldFocus] {
+		if(GetFocus() != oldFocus) {
 			focusChanged = true;
 		}
 	}, 100);
@@ -3763,7 +3762,7 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 	if(!focusChanged) {
 		outputMessage(s);
 	}
-	*guard = false;
+	later.cancel();
 }
 
 void cmdhRemoveItems(int command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3693,33 +3693,45 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 		}
 		return count;
 	};
+	ostringstream s;
 	if(start == end) {
-		outputMessage(translate("no time selection"));
+		s << translate("no time selection");
 	} else {
 		switch (command->gaccel.accel.cmd) {
-			case 40060: // Item: Copy selected area of items
-			case 40014: { // Item: Copy loop of selected area of audio items
+			case 40060:{ // Item: Copy selected area of items
 				if(selItems == 0) {
-					outputMessage(translate("no items selected"));
+					s << translate("no items selected");
 					break;
 				}
 				int count = countAffected(GetSelectedMediaItem, selItems);
 				// Translators: used for  "Item: Copy selected area of items".
 				// {} is replaced by the number of items affected.
-				outputMessage(format(
-					translate_plural("selected area of {} item copied", "selected area of {} items copied", count), count));
+				s << format(
+					translate_plural("selected area of {} item copied", "selected area of {} items copied", count), count);
+				break;
+			}
+			case 40014: { // Item: Copy loop of selected area of audio items
+				if(selItems == 0) {
+					s << translate("no items selected");
+					break;
+				}
+				int count = countAffected(GetSelectedMediaItem, selItems);
+				// Translators: used for  "Item: Copy loop of selected area of audio items".
+				// {} is replaced by the number of items affected.
+				s << format(
+					translate_plural("loop of selected area of {} item copied", "loop of selected area of {} items copied", count), count);
 				break;
 			}
 			case 41296: { // Item: Duplicate selected area of items
 				if(selItems == 0) {
-					outputMessage(translate("no items selected"));
+					s << translate("no items selected");
 					break;
 				}
 				int count = countAffected(GetSelectedMediaItem, selItems);
 				// Translators: used for  "Item: Duplicate selected area of items".
 				// {} is replaced by the number of items affected.
-				outputMessage(format(
-					translate_plural("selected area of {} item duplicated", "selected area of {} items duplicated", count), count));
+				s << format(
+					translate_plural("selected area of {} item duplicated", "selected area of {} items duplicated", count), count);
 				break;
 			}
 			default: {
@@ -3729,18 +3741,29 @@ void cmdRemoveOrCopyAreaOfItems(Command* command) {
 				} else {
 					count = countAffected(GetSelectedMediaItem, selItems);
 				}
-				ostringstream s;
 				// Translators: used for  "Item: Cut selected area of items" and "Item:
 				// Remove selected area of items".  {} is replaced by the number of items
 				// affected.
 				s << format(
 					translate_plural("selected area of {} item removed", "selected area of {} items removed", count), count);
 				maybeAddRippleMessage(s, command->gaccel.accel.cmd);
-				outputMessage(s);
 			}
 		}
 	}
+	// the command might show an error, so we need to avoid speaking if the focus changes
+	HWND oldFocus = GetFocus();
+	bool focusChanged = false;
+	auto guard = make_shared<bool>(true); // guard against the lambda accessing out of scope variables
+	auto later = CallLater([&focusChanged, &oldFocus, guard] {
+		if(*guard && GetFocus() != oldFocus) {
+			focusChanged = true;
+		}
+	}, 100);
 	Main_OnCommand(command->gaccel.accel.cmd, 0);
+	if(!focusChanged) {
+		outputMessage(s);
+	}
+	*guard = false;
 }
 
 void cmdhRemoveItems(int command) {


### PR DESCRIPTION
… fixes ##1074

@jcsteh this action sometimes pops up an error dialog so I did an ugly CallLater hack to prevent it speaking in that case. Not sure if there's a cleaner way to do that.