### PR TITLE
Added new action OSARA; Select items under edit cursor on selected tracks

### DIFF
--- a/config/mac/reaper-kb.ini
+++ b/config/mac/reaper-kb.ini
@@ -1,6 +1,6 @@
 ACT 1 0 "9ce484e08ce236468c6e6e9ed2916fe9" "Custom: Edit marker at cursor" 40614 41988
 ACT 1 0 "a77ae1752661af4bb75a473af340ff6a" "Custom: Move to item peak and report the position" _SWS_FINDITEMPEAK 1016 _OSARA_CURSORPOS
-ACT 1 0 "eee7137cb72ad2489abf82cde9121025" "Custom: Select and split item under edit or play cursor" _XENAKIOS_SELITEMSUNDEDCURSELTX 40012
+ACT 1 0 "eee7137cb72ad2489abf82cde9121025" "Custom: Select and split item under edit or play cursor" _OSARA_MUTENEXTMESSAGE _OSARA_SELITEMSEDITCURSSELTRACKS 40012
 ACT 1 0 "398ab1cb434549dcabcdcecea7e3be0f" "Custom: Set time selection  between items across tracks and preview" 41167 40625 41168 40626 40630 40084 40317
 ACT 0 0 "8055a6e2e9b34397a3172ab0359549cf" "Custom: Set time selection end and preview edit" 40626 40630 40084 40317
 ACT 1 0 "0560a0aa82a4473b9a964e7de01e588f" "Custom: Solo exclusive next track" 40340 40285 40728
@@ -242,7 +242,7 @@ KEY 5 120 40917 0		 # Main : Shift+F9 : OVERRIDE DEFAULT : Master track: Toggle 
 KEY 25 81 40929 0		 # Main : Cmd+Opt+Q : File: Open render queue
 KEY 25 48 40938 0		 # Main : Cmd+Opt+0 : Item properties: Reset item take gain to +0dB (un-normalize)
 KEY 17 32803 41040 0		 # Main : Opt+End : Move edit cursor to start of next measure
-KEY 17 32804 41041 0		 # Main : Opt+Home : Move edit cursor to start of current measure
+KEY 17 32804 41041 0		 # Main : Opt+Home : Move edit cursor to start of current/previous measure
 KEY 1 32802 41042 0		 # Main : Page Down : OVERRIDE DEFAULT : Move edit cursor forward one measure
 KEY 1 32801 41043 0		 # Main : Page Up : OVERRIDE DEFAULT : Move edit cursor back one measure
 KEY 9 32802 41044 0		 # Main : Cmd+Page Down : OVERRIDE DEFAULT : Move edit cursor forward one beat
@@ -379,6 +379,7 @@ KEY 17 76 _OSARA_SELECTNEXTENV 0		 # Main : Opt+L : OVERRIDE DEFAULT : OSARA: Se
 KEY 21 76 _OSARA_SELECTPREVENV 0		 # Main : Opt+Shift+L : OSARA: Select previous track/take envelope (depending on focus)
 KEY 5 32803 _OSARA_SELFROMCURSORTOEND 0		 # Main : Shift+End : OSARA: Select from cursor to end of project
 KEY 5 32804 _OSARA_SELFROMCURSORTOSTART 0		 # Main : Shift+Home : OSARA: Select from cursor to start of project
+KEY 5 65 _OSARA_SELITEMSEDITCURSSELTRACKS 0		 # Main : Shift+A : OSARA: Select items under edit cursor on selected tracks
 KEY 17 120 _OSARA_SETPHASENORMALALLTRACKS 0		 # Main : Opt+F9 : OSARA: Set phase normal for all tracks
 KEY 1 123 _OSARA_SHORTCUTHELP 0		 # Main : F12 : OSARA: Toggle shortcut help
 KEY 29 76 _OSARA_TOGGLEGLOBALAUTOMATIONLATCHPREVIEW 0		 # Main : Cmd+Opt+Shift+L : OSARA: Toggle global automation override between latch preview and off
@@ -446,7 +447,6 @@ KEY 16 36 _XENAKIOS_RESAMPLE_UPNUDA 0		 # Main : Opt+$ : Xenakios/SWS: Nudge ite
 KEY 21 52 _XENAKIOS_RESAMPLE_UPNUDA 0		 # Main : Opt+Shift+4 : Xenakios/SWS: Nudge item pitch up (resampled) A
 KEY 16 94 _XENAKIOS_RESAMPLE_UPNUDB 0		 # Main : Opt+^ : Xenakios/SWS: Nudge item pitch up (resampled) B
 KEY 21 54 _XENAKIOS_RESAMPLE_UPNUDB 0		 # Main : Opt+Shift+6 : Xenakios/SWS: Nudge item pitch up (resampled) B
-KEY 5 65 _XENAKIOS_SELITEMSUNDEDCURSELTX 0		 # Main : Shift+A : Xenakios/SWS: Select items under edit cursor on selected tracks
 KEY 17 83 _XENAKIOS_SETPANVOLSELTAKES 0		 # Main : Opt+S : OVERRIDE DEFAULT : Xenakios/SWS: Set volume and pan of selected takes...
 KEY 0 96 _XENAKIOS_SHOW_COMMANDPARAMS 0		 # Main : ` : OVERRIDE DEFAULT : Xenakios/SWS: Command parameters
 KEY 25 32 _XENAKIOS_TIMERTEST1 0		 # Main : Cmd+Opt+Space : Xenakios/SWS: Play selected items once

--- a/config/windows/reaper-kb.ini
+++ b/config/windows/reaper-kb.ini
@@ -1,6 +1,6 @@
 ACT 1 0 "9ce484e08ce236468c6e6e9ed2916fe9" "Custom: Edit marker at cursor" 40614 41988
 ACT 1 0 "a77ae1752661af4bb75a473af340ff6a" "Custom: Move to item peak and report the position" _SWS_FINDITEMPEAK 1016 _OSARA_CURSORPOS
-ACT 1 0 "eee7137cb72ad2489abf82cde9121025" "Custom: Select and split item under edit or play cursor" _XENAKIOS_SELITEMSUNDEDCURSELTX 40012
+ACT 1 0 "eee7137cb72ad2489abf82cde9121025" "Custom: Select and split item under edit or play cursor" _OSARA_MUTENEXTMESSAGE _OSARA_SELITEMSEDITCURSSELTRACKS 40012
 ACT 1 0 "0560a0aa82a4473b9a964e7de01e588f" "Custom: Solo exclusive next track" 40340 40285 40728
 ACT 1 0 "ce078dd0845b44aebcc49334dfa669c6" "Custom: Solo exclusive previous track" 40340 40286 40728
 ACT 1 0 "687988e0f1d862478b1407f864d3fd6b" "Custom: add stretch marker to cursor and snap to grid" 41842 40842 40625 40841 40841 40626 41847 40630 40841 40635
@@ -228,7 +228,7 @@ KEY 5 120 40917 0		 # Main : Shift+F9 : OVERRIDE DEFAULT : Master track: Toggle 
 KEY 25 81 40929 0		 # Main : Ctrl+Alt+Q : File: Open render queue
 KEY 25 48 40938 0		 # Main : Ctrl+Alt+0 : Item properties: Reset item take gain to +0dB (un-normalize)
 KEY 17 32803 41040 0		 # Main : Alt+END : Move edit cursor to start of next measure
-KEY 17 32804 41041 0		 # Main : Alt+HOME : Move edit cursor to start of current measure
+KEY 17 32804 41041 0		 # Main : Alt+HOME : Move edit cursor to start of current/previous measure
 KEY 1 32802 41042 0		 # Main : PGDOWN : OVERRIDE DEFAULT : Move edit cursor forward one measure
 KEY 1 32801 41043 0		 # Main : PGUP : OVERRIDE DEFAULT : Move edit cursor back one measure
 KEY 9 32802 41044 0		 # Main : Ctrl+PGDOWN : OVERRIDE DEFAULT : Move edit cursor forward one beat
@@ -362,6 +362,7 @@ KEY 17 76 _OSARA_SELECTNEXTENV 0		 # Main : Alt+L : OVERRIDE DEFAULT : OSARA: Se
 KEY 21 76 _OSARA_SELECTPREVENV 0		 # Main : Alt+Shift+L : OSARA: Select previous track/take envelope (depending on focus)
 KEY 5 32803 _OSARA_SELFROMCURSORTOEND 0		 # Main : Shift+END : OSARA: Select from cursor to end of project
 KEY 5 32804 _OSARA_SELFROMCURSORTOSTART 0		 # Main : Shift+HOME : OSARA: Select from cursor to start of project
+KEY 5 65 _OSARA_SELITEMSEDITCURSSELTRACKS 0		 # Main : Shift+A : OSARA: Select items under edit cursor on selected tracks
 KEY 17 120 _OSARA_SETPHASENORMALALLTRACKS 0		 # Main : Alt+F9 : OSARA: Set phase normal for all tracks
 KEY 1 123 _OSARA_SHORTCUTHELP 0		 # Main : F12 : OSARA: Toggle shortcut help
 KEY 1 220 _OSARA_TEMPOTIMESIG 0		 # Main : \ : 
@@ -422,7 +423,6 @@ KEY 21 51 _XENAKIOS_RESAMPLE_DOWNNUDA 0		 # Main : Alt+Shift+3 : Xenakios/SWS: N
 KEY 21 53 _XENAKIOS_RESAMPLE_DOWNNUDB 0		 # Main : Alt+Shift+5 : Xenakios/SWS: Nudge item pitch down (resampled) B
 KEY 21 52 _XENAKIOS_RESAMPLE_UPNUDA 0		 # Main : Alt+Shift+4 : Xenakios/SWS: Nudge item pitch up (resampled) A
 KEY 21 54 _XENAKIOS_RESAMPLE_UPNUDB 0		 # Main : Alt+Shift+6 : Xenakios/SWS: Nudge item pitch up (resampled) B
-KEY 5 65 _XENAKIOS_SELITEMSUNDEDCURSELTX 0		 # Main : Shift+A : Xenakios/SWS: Select items under edit cursor on selected tracks
 KEY 17 83 _XENAKIOS_SETPANVOLSELTAKES 0		 # Main : Alt+S : OVERRIDE DEFAULT : Xenakios/SWS: Set volume and pan of selected takes...
 KEY 1 192 _XENAKIOS_SHOW_COMMANDPARAMS 0		 # Main : ' : Xenakios/SWS: Command parameters
 KEY 25 32 _XENAKIOS_TIMERTEST1 0		 # Main : Ctrl+Alt+Space : Xenakios/SWS: Play selected items once

--- a/readme.md
+++ b/readme.md
@@ -783,7 +783,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: go to first track: Control+Alt+Home
 - OSARA: go to last track: Control+Alt+End
 - OSARA: go to master track: Control+Alt+Shift+Home
-- OSARA: Select items under edit cursor on selected tracks
+- OSARA: Select items under edit cursor on selected tracks: Shift+A
 - OSARA: Move to next item (leaving other items selected): Control+Shift+RightArrow
 - OSARA: Move to previous item (leaving other items selected): Control+Shift+LeftArrow
 - OSARA: View properties for current media item/take/automation item (depending on focus): Shift+F2

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,6 @@ Most of these are actions built into REAPER, but a few are useful actions from t
 - Item grouping: Remove items from group: Control+Shift+G
 - Item grouping: Select all items in groups: Shift+G
 - Item: Select all items in current time selection: Control+Shift+A
-- (SWS extension) Xenakios/SWS: Select items under edit cursor on selected tracks: Shift+A
 - Item properties: Toggle mute: Control+F5
 - Item properties: Toggle solo exclusive: Control+F6
 - Item properties: Toggle lock
@@ -784,6 +783,7 @@ OSARA also includes some other miscellaneous actions.
 - OSARA: go to first track: Control+Alt+Home
 - OSARA: go to last track: Control+Alt+End
 - OSARA: go to master track: Control+Alt+Shift+Home
+- OSARA: Select items under edit cursor on selected tracks
 - OSARA: Move to next item (leaving other items selected): Control+Shift+RightArrow
 - OSARA: Move to previous item (leaving other items selected): Control+Shift+LeftArrow
 - OSARA: View properties for current media item/take/automation item (depending on focus): Shift+F2
@@ -865,6 +865,7 @@ This list is worth referencing when making your own key map additions, assigning
 - Global automation override: No override (set automation modes per track)
 - Grid: Set to 1/64
 - Grid: Set to 1/128
+- (SWS extension) Xenakios/SWS: Select items under edit cursor on selected tracks
 - Item: Invert selection
 - Xenakios/SWS: Invert item selection
 - Edit: Cut items

--- a/src/osara.h
+++ b/src/osara.h
@@ -121,6 +121,9 @@
 #define REAPERAPI_WANT_TakeFX_SetParam
 #define REAPERAPI_WANT_TakeFX_FormatParamValue
 #define REAPERAPI_WANT_plugin_getapi
+#define REAPERAPI_WANT_PreventUIRefresh
+#define REAPERAPI_WANT_UpdateArrange
+#define REAPERAPI_WANT_Undo_OnStateChangeEx2
 #define REAPERAPI_WANT_Envelope_FormatValue
 #define REAPERAPI_WANT_CountTrackEnvelopes
 #define REAPERAPI_WANT_GetTrackEnvelope

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3980,27 +3980,24 @@ void cmdManageTempoTimeSigMarkers(Command* command) {
 
 void cmdSelectItemsUnderEditCursorOnSelectedTracks(Command* command) {
 	vector<MediaItem*> items;
-	for (int i = 0; i < CountTracks(nullptr); ++i) {
-		MediaTrack* track = GetTrack(nullptr, i);
-		for (int j = 0; j < CountTrackMediaItems(track); ++j) {
-			MediaItem* item = GetTrackMediaItem(track, j);
+	for (int t = 0; t < CountSelectedTracks(nullptr); ++t) {
+		MediaTrack* track = GetSelectedTrack2(nullptr, t, false);
+		for (int i = 0; i < CountTrackMediaItems(track); ++i) {
+			MediaItem* item = GetTrackMediaItem(track, i);
 			items.push_back(item);
 		}
 	}
-	PreventUIRefresh(1); // SWS use this
+	PreventUIRefresh(1); // Bringing this line in from SWS...
+	// API isn't clear waht this does, best guess is it's more efficient to redraw UI once for the entire operation
+	// instead of redrawing for every item we select.
 	Main_OnCommand(40289,0); // unselect all items
-	int i;
 	double cursorPosition=GetCursorPosition();
-	for (i=0;i<(int)items.size();++i) {
-		MediaTrack* track = (MediaTrack*)GetSetMediaItemInfo(items[i],"P_TRACK", 0);
-		if (isTrackSelected(track)) {
-			double itemStart = *(double*)GetSetMediaItemInfo(items[i], "D_POSITION", 0);
-			double itemLength = *(double*)GetSetMediaItemInfo(items[i], "D_LENGTH", 0);
-			double itemEnd = itemStart + itemLength;
-			if (cursorPosition >= itemStart && cursorPosition <= itemEnd) {
-				bool makeSelected = true;
-				GetSetMediaItemInfo(items[i], "B_UISEL", &makeSelected);
-			}
+	for (MediaItem* item: items) {
+		double itemStart = *(double*)GetSetMediaItemInfo(item, "D_POSITION", 0);
+		double itemLength = *(double*)GetSetMediaItemInfo(item, "D_LENGTH", 0);
+		double itemEnd = itemStart + itemLength;
+		if (cursorPosition >= itemStart && cursorPosition <= itemEnd) {
+			GetSetMediaItemInfo(item, "B_UISEL", &bTrue);
 		}
 	}
 	PreventUIRefresh(-1);
@@ -5417,7 +5414,8 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Configure REAPER for optimal screen reader accessibility")}, "OSARA_CONFIGREAPEROPTIMAL", cmdConfigReaperOptimal},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Check for update")}, "OSARA_UPDATE", cmdCheckForUpdate},
 	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Open online documentation")}, "OSARA_OPENDOC", cmdOpenDoc},
-	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Select items under edit cursor on selected tracks")}, "OSARA_SELITEMSEDITCURSSELTRACKS", cmdSelectItemsUnderEditCursorOnSelectedTracks},	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers")}, "OSARA_MANAGETEMPOTIMESIGMARKERS", cmdManageTempoTimeSigMarkers},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Select items under edit cursor on selected tracks")}, "OSARA_SELITEMSEDITCURSSELTRACKS", cmdSelectItemsUnderEditCursorOnSelectedTracks},
+	{MAIN_SECTION, {DEFACCEL, _t("OSARA: Report tempo and time signature at play cursor; press twice to add/edit tempo markers")}, "OSARA_MANAGETEMPOTIMESIGMARKERS", cmdManageTempoTimeSigMarkers},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Enable noncontiguous selection/toggle selection of current chord/note")}, "OSARA_MIDITOGGLESEL", cmdMidiToggleSelection},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to next chord")}, "OSARA_NEXTCHORD", cmdMidiMoveToNextChord},
 	{MIDI_EDITOR_SECTION, {DEFACCEL, _t("OSARA: Move to previous chord")}, "OSARA_PREVCHORD", cmdMidiMoveToPreviousChord},

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -3987,9 +3987,9 @@ void cmdSelectItemsUnderEditCursorOnSelectedTracks(Command* command) {
 			items.push_back(item);
 		}
 	}
-	PreventUIRefresh(1); // Bringing this line in from SWS...
-	// API isn't clear waht this does, best guess is it's more efficient to redraw UI once for the entire operation
-	// instead of redrawing for every item we select.
+	// We might select multiple items. To improve performance, only refresh the UI
+	// after the entire operation is complete.
+	PreventUIRefresh(1);
 	Main_OnCommand(40289,0); // unselect all items
 	double cursorPosition=GetCursorPosition();
 	for (MediaItem* item: items) {


### PR DESCRIPTION
This PR adds a new OSARA action to replace an SWS one, partly because code from the original contributor is no longer maintained, also because it's been bothering me that something fundamental like splitting items has an external dependency. It follows the SWS implementation closely, but is easier to read and is future-proofed by using newer APIs. I intend to follow up soon with improved feedback when items couldn't be split, figured I should get this new action checked over and merged before I go any deeper down the rabbit hole though.