### PR TITLE
Fix reporting of the slider in the Parameters dialog with Windows Narrator.

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -79,6 +79,7 @@ if env["PLATFORM"] == "win32":
 		"Advapi32",
 		"UIAutomationCore",
 		"ws2_32",
+		"Comctl32",
 	]
 
 else: # Mac

--- a/src/controlSurface.cpp
+++ b/src/controlSurface.cpp
@@ -17,6 +17,9 @@
 #include "paramsUi.h"
 #include "midiEditorCommands.h"
 #include "translation.h"
+#ifdef _WIN32
+# include "uia.h"
+#endif
 
 using namespace std;
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -353,14 +353,6 @@ std::string narrow(const std::wstring& text);
 
 extern IAccPropServices* accPropServices;
 
-// uia.cpp
-bool initializeUia();
-bool hasTriedToInitializeUia();
-bool terminateUia();
-bool shouldUseUiaNotifications();
-bool sendUiaNotification(const std::string& message, bool interrupt = true);
-void resetUia();
-
 #else
 // These macros exist on Windows but aren't defined by Swell for Mac.
 #define ComboBox_GetCurSel(hwnd) (int)SendMessage(hwnd, CB_GETCURSEL, 0, 0)

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -16,6 +16,7 @@
 #include <atlcomcli.h>
 // We only need this on Windows and it apparently causes compilation issues on Mac.
 #include <codecvt>
+#include "uia.h"
 #else
 #include "osxa11y_wrapper.h" // NSA11y wrapper for OS X accessibility API
 #endif

--- a/src/uia.h
+++ b/src/uia.h
@@ -1,0 +1,55 @@
+/*
+ * OSARA: Open Source Accessibility for the REAPER Application
+ * UI Automation header
+ * Copyright 2019-2025 Leonard de Ruijter, James Teh
+ * License: GNU General Public License version 2.0
+ */
+
+#pragma once
+
+#include <uiautomation.h>
+
+bool initializeUia();
+bool hasTriedToInitializeUia();
+bool terminateUia();
+bool shouldUseUiaNotifications();
+bool sendUiaNotification(const std::string& message, bool interrupt = true);
+void resetUia();
+
+class UiaProvider : public IRawElementProviderSimple {
+	public:
+	UiaProvider(_In_ HWND hwnd): controlHWnd(hwnd), refCount(0) {}
+
+	// IUnknown methods
+	ULONG STDMETHODCALLTYPE AddRef() override;
+	ULONG STDMETHODCALLTYPE Release() override;
+	HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid,
+		_Outptr_ void** ppInterface) override;
+
+	// IRawElementProviderSimple methods
+	HRESULT STDMETHODCALLTYPE get_ProviderOptions(
+		_Out_ ProviderOptions* pRetVal) final;
+	HRESULT STDMETHODCALLTYPE GetPatternProvider(PATTERNID patternId,
+		_Outptr_result_maybenull_ IUnknown** pRetVal) override;
+	HRESULT STDMETHODCALLTYPE GetPropertyValue(PROPERTYID propertyId,
+		_Out_ VARIANT* pRetVal) override;
+	HRESULT STDMETHODCALLTYPE get_HostRawElementProvider(
+		IRawElementProviderSimple** pRetVal) final;
+
+	protected:
+	virtual ~UiaProvider() = default;
+
+	virtual long getControlType() const {
+		// Stop Narrator from ever speaking this as a window.
+		return UIA_CustomControlTypeId;
+	}
+
+	virtual bool isFocusable() const {
+		return false;
+	}
+
+	HWND controlHWnd; // The HWND for the control.
+
+	private:
+	ULONG refCount; // Ref Count for this COM object
+};


### PR DESCRIPTION
Narrator uses UIA, not MSAA. Unfortunately, we can't annotate the UIA Value pattern's Value property. Instead, we use a custom UIA implementation.

Fixes #758.