### PR TITLE
dev: Clean up some code related to COM references.

### DIFF
--- a/src/osara.h
+++ b/src/osara.h
@@ -346,12 +346,13 @@ MediaItem* getItemWithFocus();
 
 #ifdef _WIN32
 #include <string>
+#include <atlcomcli.h>
 #include <oleacc.h>
 
 std::wstring widen(const std::string& text);
 std::string narrow(const std::wstring& text);
 
-extern IAccPropServices* accPropServices;
+extern CComPtr<IAccPropServices> accPropServices;
 
 #else
 // These macros exist on Windows but aren't defined by Swell for Mac.

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -13,7 +13,6 @@
 #include <oleacc.h>
 #include <Windowsx.h>
 #include <Commctrl.h>
-#include <atlcomcli.h>
 // We only need this on Windows and it apparently causes compilation issues on Mac.
 #include <codecvt>
 #include "uia.h"
@@ -50,7 +49,7 @@ HINSTANCE pluginHInstance;
 HWND mainHwnd;
 #ifdef _WIN32
 DWORD guiThread;
-IAccPropServices* accPropServices = nullptr;
+CComPtr<IAccPropServices> accPropServices;
 #endif
 
 // We cache the last reported time so we can report just the components which have changed.
@@ -5883,7 +5882,7 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		peakWatcher::initialize();
 
 #ifdef _WIN32
-		if (CoCreateInstance(CLSID_AccPropServices, nullptr, CLSCTX_SERVER, IID_IAccPropServices, (void**)&accPropServices) != S_OK) {
+		if (accPropServices.CoCreateInstance(CLSID_AccPropServices) != S_OK) {
 			return 0;
 		}
 		guiThread = GetWindowThreadProcessId(mainHwnd, nullptr);
@@ -5929,7 +5928,7 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		UnhookWindowsHookEx(keyboardHook);
 		UnhookWinEvent(winEventHook);
 		terminateUia();
-		accPropServices->Release();
+		accPropServices = nullptr;
 #else
 		NSA11yWrapper::destroy();
 #endif

--- a/src/uia.cpp
+++ b/src/uia.cpp
@@ -67,15 +67,12 @@ HRESULT STDMETHODCALLTYPE UiaProvider::QueryInterface(_In_ REFIID riid,
 	if (!ppInterface) {
 		return E_INVALIDARG;
 	}
-	if (riid == __uuidof(IUnknown)) {
-		*ppInterface =static_cast<IRawElementProviderSimple*>(this);
-	} else if (riid == __uuidof(IRawElementProviderSimple)) {
-		*ppInterface =static_cast<IRawElementProviderSimple*>(this);
+	if (riid == __uuidof(IUnknown) || riid == __uuidof(IRawElementProviderSimple)) {
+		*ppInterface = CComPtr<IRawElementProviderSimple>(this).Detach();
 	} else {
 		*ppInterface = nullptr;
 		return E_NOINTERFACE;
 	}
-	(static_cast<IUnknown*>(*ppInterface))->AddRef();
 	return S_OK;
 }
 
@@ -133,11 +130,10 @@ HRESULT STDMETHODCALLTYPE TextSliderUiaProvider::QueryInterface(
 		return E_INVALIDARG;
 	}
 	if (riid == __uuidof(IValueProvider)) {
-		*ppInterface =static_cast<IValueProvider*>(this);
+		*ppInterface = CComPtr<IValueProvider>(this).Detach();
 	} else {
 		return UiaProvider::QueryInterface(riid, ppInterface);
 	}
-	(static_cast<IUnknown*>(*ppInterface))->AddRef();
 	return S_OK;
 }
 
@@ -145,8 +141,7 @@ HRESULT STDMETHODCALLTYPE TextSliderUiaProvider::GetPatternProvider(
 	PATTERNID patternId, _Outptr_result_maybenull_ IUnknown** pRetVal
 ) {
 	if (patternId == UIA_ValuePatternId) {
-		*pRetVal = static_cast<IValueProvider*>(this);
-		AddRef();
+		*pRetVal = CComPtr<IValueProvider>(this).Detach();
 	} else {
 		*pRetVal = nullptr;
 	}


### PR DESCRIPTION
1. Use CComPtr for IAccPropServices instead of a raw pointer.
2. Use CComPtr for UiaProvider QueryInterface methods instead of raw pointers and AddRef calls.

No functional change, just code cleanup.