### PR TITLE
Fix broken feedback for the arrow keys in the virtual MIDI keyboard if it opens when REAPER starts.

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -2472,9 +2472,6 @@ int vkbTranslateAccel(MSG* msg, accelerator_register_t* accelReg) {
 		return 0; // Normal handling.
 	}
 	if (!IsWindow(vkbHwnd)) {
-		// The dialog is dead. Ideally, we would unregister. However, if we do,
-		// subsequent registrations of our hook never intercept key presses in the
-		// virtual keyboard. So, we just have to leave this registered.
 		vkbHwnd = nullptr;
 		return 0;
 	}


### PR DESCRIPTION
Previously, if the virtual MIDI keyboard was configured to open when REAPER starts, this feedback would fail to work until REAPER was restarted with the keyboard closed. To fix this, always register the hook as soon as OSARA loads.