### PR TITLE
Param sliders for kontakt and kk

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -340,12 +340,14 @@ class ParamsDialog {
 	}
 
 	void updateValue() {
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));	
-		this->valText = this->param->getValueText(this->val);
-		this->updateValueText();
-		if (this->param->isEditable) {
-			SetWindowText(this->valueEdit, this->param->getValueForEditing().c_str());
-		}
+		// Testing callLater to delay operations.
+		CallLater([this]() {
+			this->valText = this->param->getValueText(this->val);
+			this->updateValueText();
+			if (this->param->isEditable) {
+				SetWindowText(this->valueEdit, this->param->getValueForEditing().c_str());
+			}
+		}, 5); // 5 milliseconds delay
 	}
 
 	void onParamChange() {

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -347,7 +347,7 @@ class ParamsDialog {
 			if (this->param->isEditable) {
 				SetWindowText(this->valueEdit, this->param->getValueForEditing().c_str());
 			}
-		}, 5); // 5 milliseconds delay
+		}, 50); // 50 milliseconds delay
 	}
 
 	void onParamChange() {

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -340,14 +340,11 @@ class ParamsDialog {
 	}
 
 	void updateValue() {
-		// Testing callLater to delay operations.
-		CallLater([this]() {
-			this->valText = this->param->getValueText(this->val);
-			this->updateValueText();
-			if (this->param->isEditable) {
-				SetWindowText(this->valueEdit, this->param->getValueForEditing().c_str());
-			}
-		}, 50); // 50 milliseconds delay
+		this->valText = this->param->getValueText(this->val);
+		this->updateValueText();
+		if (this->param->isEditable) {
+			SetWindowText(this->valueEdit, this->param->getValueForEditing().c_str());
+		}
 	}
 
 	void onParamChange() {
@@ -360,6 +357,8 @@ class ParamsDialog {
 	}
 
 	void onSliderChange(double newVal) {
+		static CallLater later;
+		later.cancel();
 		if (newVal == this->val
 				|| newVal < this->param->min || newVal > this->param->max) {
 			return;
@@ -389,7 +388,9 @@ class ParamsDialog {
 			}
 		}
 		this->param->setValue(this->val);
-		this->updateValue();
+		later = CallLater([this]() {
+			this->updateValue();
+		}, 50);
 	}
 
 	void onValueEdited() {

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -861,8 +861,8 @@ class FxParam: public Param {
 				}
 			}
 		} else {
-			this->step = (this->max - this->min) / 1000;
-			this->largeStep = this->step * 20;
+			this->step = (this->max - this->min) / 50;
+			this->largeStep = this->step * 5;
 		}
 		this->isEditable = true;
 		// Set this as the last touched FX and FX parameter, as well as the last

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -5,6 +5,8 @@
  * License: GNU General Public License version 2.0
  */
 
+#include <chrono>
+#include <thread>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -338,6 +340,7 @@ class ParamsDialog {
 	}
 
 	void updateValue() {
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));	
 		this->valText = this->param->getValueText(this->val);
 		this->updateValueText();
 		if (this->param->isEditable) {
@@ -861,8 +864,8 @@ class FxParam: public Param {
 				}
 			}
 		} else {
-			this->step = (this->max - this->min) / 50;
-			this->largeStep = this->step * 5;
+			this->step = (this->max - this->min) / 1000;
+			this->largeStep = this->step * 20;
 		}
 		this->isEditable = true;
 		// Set this as the last touched FX and FX parameter, as well as the last


### PR DESCRIPTION
After discussion in #593, I've been investigating why values aren't being reported consistently when adjusting sliders in OSARA's FX Parameters dialog. Test plug-ins here have been Komplete Kontrol 3, Kontakt 6, 7 and 8.
STR:
1. Running a recent OSARA snapshot, load an instrument in any of the plug-ins specified above.
2. Go into the OSARA FX Parameters dialog, find a volume parameter.
3. Move the slider with arrows, page keys, home or end. All will seem ok until you change the direction you're moving in. Compare the consistency of formatted values being reported to the values displayed in OSARA's accompanying edit field. The former jumps all over the place when switching direction, the latter stays consistent and is the true value (can be verified by listening to the effect your adjustments are having on an instrument).
4. Now switch to the latest snapshot linked in this PR and repeat the test. This time you should find the formatted values are reported consistently when changing direction and jumping to ends of slider.

A 5ms sleep in paramsUI.cpp before we update value seems to stabilize reporting. As yet I don't know why that helps and I'm not proposing this as an actual solution, just a temporary hack to see whether behaviour also improves on a wider pool of machines. I'm especially interested in hearing about whether it helps on older/slower Windows and Macs. Not sure how long we need to wait for yet, or what a nicer implementation would be.

Tagging @timtam and @jennykbrennan, they've been helping chase it.