### PR TITLE
Improve Actions build times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ defaults:
 env:
   publisher: James Teh
   VSCMD_SKIP_SENDTELEMETRY: 1
+  SCONS_CACHE_MSVC_CONFIG: 1
 concurrency:
   # There's no point continuing to run a build if it's already outdated by
   # another commit.
@@ -37,6 +38,7 @@ jobs:
           fi
           if [ ${{ matrix.os }} == windows-latest ]; then
             echo os=windows >> "$GITHUB_ENV"
+            echo "CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
           else
             echo os=mac >> "$GITHUB_ENV"
           fi
@@ -49,6 +51,13 @@ jobs:
         run: python tools/sortKeymap.py -t config/${{ env.os }}/reaper-kb.ini
       - name: setup
         run: pip install scons
+      - id: get-scons-msvc-cache
+        name: Get SCons MSVC Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~\scons_msvc_cache.json
+          key: ${{ env.CACHE_KEY }}
+          fail-on-cache-miss: false
       - name: Windows setup
         if: ${{ matrix.os == 'windows-latest' }}
         # Use NSIS 2.46 to reduce AV false positives.
@@ -61,6 +70,12 @@ jobs:
         run: brew install php
       - name: build
         run: scons --debug=time "publisher=${{ env.publisher }}" version=${{ env.version }}
+      - name: Get SCons MSVC Cache
+        if: steps.get-scons-msvc-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~\scons_msvc_cache.json
+          key: ${{ env.CACHE_KEY }}
       - name: sign
         if: ${{ github.event_name == 'push' && matrix.os == 'windows-latest' }}
         uses: azure/trusted-signing-action@v0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - name: set env
         run: |
+          echo "CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
           if [ $GITHUB_EVENT_NAME == push ]; then
             # For example: 2025.3.7.2011,23631c6e
             # We add 1800 to GITHUB_RUN_NUMBER because we can't set the
@@ -38,7 +39,6 @@ jobs:
           fi
           if [ ${{ matrix.os }} == windows-latest ]; then
             echo os=windows >> "$GITHUB_ENV"
-            echo "CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
           else
             echo os=mac >> "$GITHUB_ENV"
           fi
@@ -51,14 +51,12 @@ jobs:
         run: python tools/sortKeymap.py -t config/${{ env.os }}/reaper-kb.ini
       - name: setup
         run: pip install scons
-      - id: get-scons-msvc-cache
-        name: Get SCons MSVC Cache
-        if: ${{ env.CACHE_KEY != '' }}
-        uses: actions/cache/restore@v4
+      - name: SCons MSVC Cache
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: actions/cache@v4
         with:
           path: ~\scons_msvc_cache.json
           key: ${{ env.CACHE_KEY }}
-          fail-on-cache-miss: false
       - name: Windows setup
         if: ${{ matrix.os == 'windows-latest' }}
         # Use NSIS 2.46 to reduce AV false positives.
@@ -71,12 +69,6 @@ jobs:
         run: brew install php
       - name: build
         run: scons "publisher=${{ env.publisher }}" version=${{ env.version }}
-      - name: Set SCons MSVC Cache
-        if: ${{ steps.get-scons-msvc-cache.outputs.cache-hit != 'true' && matrix.os == 'windows-latest' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ~\scons_msvc_cache.json
-          key: ${{ env.CACHE_KEY }}
       - name: sign
         if: ${{ github.event_name == 'push' && matrix.os == 'windows-latest' }}
         uses: azure/trusted-signing-action@v0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: build
         run: scons --debug=time "publisher=${{ env.publisher }}" version=${{ env.version }}
       - name: Set SCons MSVC Cache
-        if: steps.get-scons-msvc-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.get-scons-msvc-cache.outputs.cache-hit != 'true' && matrix.os == 'windows-latest' }}
         uses: actions/cache/save@v4
         with:
           path: ~\scons_msvc_cache.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ defaults:
     shell: bash
 env:
   publisher: James Teh
+  VSCMD_SKIP_SENDTELEMETRY: 1
 concurrency:
   # There's no point continuing to run a build if it's already outdated by
   # another commit.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         run: pip install scons
       - id: get-scons-msvc-cache
         name: Get SCons MSVC Cache
+        if: ${{ matrix.os == 'windows-latest' }}
         uses: actions/cache/restore@v4
         with:
           path: ~\scons_msvc_cache.json
@@ -70,7 +71,7 @@ jobs:
         run: brew install php
       - name: build
         run: scons --debug=time "publisher=${{ env.publisher }}" version=${{ env.version }}
-      - name: Get SCons MSVC Cache
+      - name: Set SCons MSVC Cache
         if: steps.get-scons-msvc-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         # We need php for swell_resgen.
         run: brew install php
       - name: build
-        run: scons --debug=time "publisher=${{ env.publisher }}" version=${{ env.version }}
+        run: scons "publisher=${{ env.publisher }}" version=${{ env.version }}
       - name: Set SCons MSVC Cache
         if: ${{ steps.get-scons-msvc-cache.outputs.cache-hit != 'true' && matrix.os == 'windows-latest' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: pip install scons
       - id: get-scons-msvc-cache
         name: Get SCons MSVC Cache
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ env.CACHE_KEY != '' }}
         uses: actions/cache/restore@v4
         with:
           path: ~\scons_msvc_cache.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         # We need php for swell_resgen.
         run: brew install php
       - name: build
-        run: scons "publisher=${{ env.publisher }}" version=${{ env.version }}
+        run: scons --debug=time "publisher=${{ env.publisher }}" version=${{ env.version }}
       - name: sign
         if: ${{ github.event_name == 'push' && matrix.os == 'windows-latest' }}
         uses: azure/trusted-signing-action@v0


### PR DESCRIPTION
Fixes #1232 

The major problem here is that running vcvarsall.bat is extremely slow on GithubActions. We can fix this by caching the output of vcvarsall, as SCons offers a mechanism for this. This at least gives us a build that is around one minute faster.