### PR TITLE
Fix some cases where OSARA was incorrectly querying loop points instead of time selection.

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1699,7 +1699,7 @@ void postCopy(int command) {
 void postCopyMoveTimeSelection(int command) {
 	fakeFocus = FOCUS_RULER;
 	double start, end;
-	GetSet_LoopTimeRange(false, true, &start, &end, false);
+	GetSet_LoopTimeRange(false, false, &start, &end, false);
 	if (start == end) {
 		outputMessage(translate("no time selection"));
 		return;
@@ -3802,7 +3802,7 @@ void cmdRemoveTracks(Command* command) {
 
 void cmdRemoveOrCopyAreaOfItems(Command* command) {
 	double start, end;
-	GetSet_LoopTimeRange(false, true, &start, &end, false);
+	GetSet_LoopTimeRange(false, false, &start, &end, false);
 	int selItems = CountSelectedMediaItems(nullptr);
 	auto countAffected = [start, end](auto getFunc, int totalCount) {
 		int count = 0;


### PR DESCRIPTION
If the loop points weren't linked to time selection, this previously resulted in very confusing behaviour where OSARA incorrectly reported "no time selection" when using actions such as Edit: Cut items/tracks/envelope points (depending on focus) within time selection, if any (smart cut).