### PR TITLE
Provide feedback when inserting notes using f1-f12 step input.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -2436,7 +2436,7 @@ int midiStepTranslateAccel(MSG* msg, accelerator_register_t* accelReg) {
 	const int relativeNote = msg->wParam - VK_F1;
 	// If the shift key is being held, the cursor is not advancing, so we should
 	// not report the new position.
-	const bool reportNewPos = !(GetKeyState(VK_SHIFT) & 0x8000);
+	const bool reportNewPos = !(GetAsyncKeyState(VK_SHIFT) & 0x8000);
 	// We need to let the hook return so REAPER can handle the key and insert the
 	// note. We use CallLater to report the result.
 	CallLater([oldCount, relativeNote, reportNewPos] {

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -74,3 +74,4 @@ void postMidiToggleSnap(int command);
 void postMidiChangeZoom(int command);
 int countSelectedEvents(MediaItem_Take* take);
 const std::string getMidiNoteName(MediaTrack* track, int pitch, int channel);
+int midiStepTranslateAccel(MSG* msg, accelerator_register_t* accelReg);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -6079,7 +6079,11 @@ HWINEVENTHOOK winEventHook = nullptr;
 // This accelerator hook is registered at startup and remains registered until
 // REAPER exits.
 int translateAccel(MSG* msg, accelerator_register_t* accelReg) {
-	return vkbTranslateAccel(msg, accelReg);
+	int res = vkbTranslateAccel(msg, accelReg);
+	if (res != 0) {
+		return res;
+	}
+	return midiStepTranslateAccel(msg, accelReg);
 }
 
 extern "C" {
@@ -6156,7 +6160,9 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		accelReg.translateAccel = translateAccel;
 		accelReg.isLocal = true;
 		accelReg.user = nullptr;
-		plugin_register("accelerator", &accelReg);
+		// Using "<accelerator" causes this to be placed at the front of the
+		// accelerator list, giving it the first chance to sniff keystrokes.
+		plugin_register("<accelerator", &accelReg);
 		return 1;
 
 	} else {


### PR DESCRIPTION
Fixes #1247.
I've tested this, but additional testing and scrutiny would be ideal:

1. Normal insertion (i and shift+i), since I heavily refactored that code to make it reusable for f1-f12 step input.
2. F1-f12 in the MIDI editor without step input enabled (to make sure I didn't somehow break these).
3. Step input with f1-f12 (advances cursor).
4. Step input with shift+f1-f12 (does not advance cursor).