### PR TITLE
Let unmodified space play/stop when focused on Parameters combo box

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -582,7 +582,7 @@ Clearing the text in the Filter field shows the entire list.
 
 As an alternative to using the Parameter combo box, you can press control+tab or control+shift+tab anywhere in the dialog to move to the next or previous parameter, respectively.
 
-Space can be used to play/stop the project when focused on sliders.
+Space can be used to play/stop the project when focused on sliders or the Parameters combo box.
 Control+Space can be used to pause, thus moving the edit cursor if you want to cue up a different part of the project.
 
 Some effects expose a lot of unnamed parameters, which can make finding the useful ones challenging.

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -564,11 +564,13 @@ class ParamsDialog {
 				(VK_F1 <= msg->wParam && msg->wParam <= VK_F12) ||
 				// Anything with both alt and shift.
 				(alt && shift) ||
-				// Space.
-				(msg->wParam == VK_SPACE) ||
 				// Modified space.
 				(msg->wParam == VK_SPACE && (alt || control || shift))
 			) {
+				return -666; // Force to main window.
+			}
+			if (msg->hwnd == dialog->paramCombo && msg->wParam == VK_SPACE) {
+				// In the combo box, we also pass space to the main section.
 				return -666; // Force to main window.
 			}
 			// Anything else must go to our window so the user can interact with the

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -564,6 +564,8 @@ class ParamsDialog {
 				(VK_F1 <= msg->wParam && msg->wParam <= VK_F12) ||
 				// Anything with both alt and shift.
 				(alt && shift) ||
+				// Space.
+				(msg->wParam == VK_SPACE) ||
 				// Modified space.
 				(msg->wParam == VK_SPACE && (alt || control || shift))
 			) {


### PR DESCRIPTION
The behaviour of unmodified Space was changed in code review. I'm trying another PR with it factored into the cleaned up approach as I received several requests via REAPER Access and PMs.
Use case is that sometimes you want to have a quick listen to the project before choosing which parameter you're going to adjust next. When exploring available parameters, without unmodified Space working the way it does in this PR, users must move to a random slider before they can play/stop, they're reporting that doesn't feel intuitive.
I've checked that REAPER still passes unmodified Space through to edit fields.
If there's something I've overlooked that makes this complex or risky, feel free to close.