### PR TITLE
POC for ARM64EC osara

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -20,7 +20,11 @@ env.SetOption('num_jobs', multiprocessing.cpu_count())
 print("Building using {} jobs".format(env.GetOption('num_jobs')))
 
 if env["PLATFORM"] == "win32":
-	for arch, suffix in (("x86", "32"), ("x86_64", "64")):
+	for arch, suffix in (
+		("x86", "32"),
+		("x86_64", "64"),
+		("arm64", "_arm64ec"),
+	):
 		archEnv = Environment(tools=["msvc", "mslink", "textfile"],
 			TARGET_ARCH=arch, HOST_ARCH=arch, libSuffix=suffix,
 			version=env["version"], copyright=env["copyright"],

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -63,6 +63,10 @@ if env["PLATFORM"] == "win32":
 	env.Append(PDB="${TARGET}.pdb")
 	# having symbols usually turns this off, but we have no need for unused symbols.
 	env.Append(LINKFLAGS='/OPT:REF')
+	match env["TARGET_ARCH"]:
+		case "arm64":
+			env.Append(CCFLAGS="--target=arm64-pc-windows-msvc")
+			env.Append(LINKFLAGS="/machine:arm64")
 	sources.extend((
 		"uia.cpp",
 		env.Object("win32_utf8.obj", "#include/WDL/WDL/win32_utf8.c"),
@@ -136,12 +140,12 @@ addExternalSources("#include/fmt/src", ("format.cc", "os.cc"))
 addExternalSources(
 	"#include/WDL/WDL/jnetlib",
 	("httpGet.cpp", "connection.cpp", "asyncdns.cpp", "util.cpp"),
-	CCFLAGS="-Wno-deprecated-declarations"
+	CCFLAGS="$CCFLAGS -Wno-deprecated-declarations"
 )
 addExternalSources(
 	"#include/simpleson",
 	("json.cpp",),
-	CCFLAGS="-Wno-deprecated-declarations"
+	CCFLAGS="$CCFLAGS -Wno-deprecated-declarations"
 )
 
 env.SharedLibrary(


### PR DESCRIPTION
This pr is a proof of concept for ARM64ec osara.
The current problem is that this is not yet arm64ec, but native arm64. arm64ec doesn't yet build, but that's probably because clang 19 doesn't fully support arm64ec yet. I think we'd have to wait until clang 21 is there, and if that still doesn't support arm64ec, we probably have to switch back to native msvc.