### PR TITLE
Play MIDI note previews when tabbing to transients if a MIDI take is selected and Preferences -> Editing Behavior -> Tab through MIDI notes is enabled.

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -2444,3 +2444,27 @@ int midiStepTranslateAccel(MSG* msg, accelerator_register_t* accelReg) {
 	}, 0);
 	return 0;
 }
+
+void previewChordForMoveToTransient(MediaItem_Take* take) {
+	// We specify direction as -1 because REAPER usually positions the cursor
+	// just slightly after the note, so we need the chord just before the cursor.
+	auto chord = findChord(take, -1, {
+		true,  // start
+		true,  // end
+		true,  // channel
+		true,  // pitch
+		true,  // velocity
+		false,  // selected
+		true  // muted
+	});
+	if (chord.first == chord.second) {
+		return;
+	}
+	if (chord.first->start < GetCursorPosition() - 0.0002) {
+		// This chord is too far before the cursor; i.e. this isn't just cursor
+		// movement inaccuracy. This can happen when moving to the end of an item.
+		return;
+	}
+	vector<MidiNote> notes(chord.first, chord.second);
+	previewNotes(take, notes);
+}

--- a/src/midiEditorCommands.h
+++ b/src/midiEditorCommands.h
@@ -75,3 +75,4 @@ void postMidiChangeZoom(int command);
 int countSelectedEvents(MediaItem_Take* take);
 const std::string getMidiNoteName(MediaTrack* track, int pitch, int channel);
 int midiStepTranslateAccel(MSG* msg, accelerator_register_t* accelReg);
+void previewChordForMoveToTransient(MediaItem_Take* take);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4990,7 +4990,7 @@ void cmdDeleteAllTimeSigs(Command* command) {
 }
 
 void moveToTransient(bool previous) {
-double cursorPos = GetCursorPosition();
+	double cursorPos = GetCursorPosition();
 	bool wasPlaying = GetPlayState() & 1;
 	if (wasPlaying) {
 		// Moving to transients can be slow, so pause/stop playback so it doesn't drift
@@ -5010,10 +5010,25 @@ double cursorPos = GetCursorPosition();
 		Main_OnCommand(40376, 0); // Item navigation: Move cursor to previous transient in items
 	else
 		Main_OnCommand(40375, 0); // Item navigation: Move cursor to next transient in items
+	int size = 0;
+	auto* transFlags = (int*)get_config_var("tabtotransflag", &size);
+	if (transFlags && size == sizeof(int) && *transFlags & 1) {
+		// Preferences -> Editing Behavior -> Tab through MIDI notes is enabled.
+		if (MediaItem* item = getItemWithFocus()) {
+			if (MediaItem_Take* take = GetActiveTake(item)) {
+				if (auto* source = (PCM_source*)GetSetMediaItemTakeInfo(take, "P_SOURCE", nullptr)) {
+					const char*type = source->GetType();
+					if (type && strcmp(type, "MIDI") == 0) {
+						previewChordForMoveToTransient(take);
+					}
+				}
+			}
+		}
+	}
 	if (wasPlaying)
 		OnPlayButton();
 	double newCursorPos = GetCursorPosition();
-if(cursorPos == newCursorPos)
+	if(cursorPos == newCursorPos)
 		return;
 	reportCursorPositionPrimaryFormat();
 }


### PR DESCRIPTION
Fixes #1294.

Note that this uses the last focused item. That means this won't be very useful in some cases if you have multiple items selected. It's unclear to me whether that is a desired use case or not, and if it is, how it should be handled.