### PR TITLE
Use MidiControlChange::get in getSelectedCCs

### DIFF
--- a/src/midiEditorCommands.cpp
+++ b/src/midiEditorCommands.cpp
@@ -998,7 +998,7 @@ vector<MidiControlChange> getSelectedCCs(MediaItem_Take* take, int offset=-1) {
 		if (ccIndex == -1) {
 			break;
 		}
-		auto cc = MidiControlChange::get(take, ccIndex, {
+		ccs.push_back(MidiControlChange::get(take, ccIndex, {
 			true,  // position
 			true,  // message1
 			true,  // channel
@@ -1006,9 +1006,7 @@ vector<MidiControlChange> getSelectedCCs(MediaItem_Take* take, int offset=-1) {
 			true,  // message3,
 			true,  // selected
 			true  // muted
-		});
-		cc.position = MIDI_GetProjTimeFromPPQPos(take, cc.position);
-		ccs.push_back(cc);
+		}));
 	}
 	return ccs;
 }


### PR DESCRIPTION
@jcsteh , in PR 1192 you wondered:
"Hmm. I don't understand why we aren't using MidiControlChange::get here instead of calling MIDI_GetCC directly. We do use MidiNote::get in getSelectedNotes. Still, that's something we can clean up separately."
So this just adresses that. I'm just a bit unsure if the true/comment pairs are matched up correctly (whether the 1st cc property/parameter really is 'position' and so on), but to be honest I spoofed that from one comment from RDMurray, so it's most likely correct.