### PR TITLE
Bind "Transport: Record" action to Control+Enter and Control+NumPadEnter for alternative ways to record while focus is in VKB, FX window or other dialogs

### DIFF
--- a/config/mac/reaper-kb.ini
+++ b/config/mac/reaper-kb.ini
@@ -38,10 +38,12 @@ KEY 9 32 0 0		 # Main : Cmd+Space : DISABLED DEFAULT
 KEY 9 9 0 0		 # Main : Cmd+Tab : DISABLED DEFAULT
 KEY 1 109 1011 0		 # Main : NumPad - : OVERRIDE DEFAULT : View: Zoom out horizontal
 KEY 1 107 1012 0		 # Main : NumPad + : OVERRIDE DEFAULT : View: Zoom in horizontal
-KEY 1 32781 1013 0		 # Main : NumPad Enter : Transport: Record
 KEY 1 82 1013 0		 # Main : R : OVERRIDE DEFAULT : Transport: Record
+KEY 33 13 1013 0		 # Main : Control+Return : Transport: Record
+KEY 33 32781 1013 0		 # Main : Control+NumPad Enter : Transport: Record
 KEY 5 13 1041 0		 # Main : Shift+Return : Track: Cycle track folder state
 KEY 1 13 1042 0		 # Main : Return : OVERRIDE DEFAULT : Track: Cycle folder collapsed state
+KEY 1 32781 1042 0		 # Main : NumPad Enter : Track: Cycle folder collapsed state
 KEY 9 82 1068 0		 # Main : Cmd+R : OVERRIDE DEFAULT : Transport: Toggle repeat
 KEY 1 72 1134 0		 # Main : H : Transport: Tap tempo
 KEY 1 76 1135 0		 # Main : L : OVERRIDE DEFAULT : Options: Toggle locking
@@ -446,6 +448,8 @@ KEY 1 65 _eee7137cb72ad2489abf82cde9121025 0		 # Main : A : Custom: Select and s
 KEY 25 75 _f763830b0c370543958ed63fb1310299 0		 # Main : Cmd+Opt+K : Custom: insert/edit tempo marker and add stretch marker at cursor
 KEY 1 82 1013 100		 # Main (alt recording) : R : Transport: Record
 KEY 1 32 40044 100		 # Main (alt recording) : Space : Transport: Play/stop
+KEY 33 13 1 102		 # glob hotkey : Control+Return : 
+KEY 33 32781 1 102		 # glob hotkey : Control+NumPad Enter : 
 KEY 33 37 1 102		 # glob hotkey : Control+NumPad Left : 
 KEY 33 39 1 102		 # glob hotkey : Control+NumPad Right : 
 KEY 5 122 1 102		 # glob hotkey : Shift+F11 : 

--- a/config/windows/reaper-kb.ini
+++ b/config/windows/reaper-kb.ini
@@ -42,10 +42,12 @@ KEY 255 2536 0 0		 # Main : MediaKbd+Vol- : DISABLED DEFAULT
 KEY 255 2792 0 0		 # Main : MediaKbd+Vol+ : DISABLED DEFAULT
 KEY 255 4072 0 0		 # Main : MediaKbd+Mail : DISABLED DEFAULT
 KEY 5 119 0 0		 # Main : Shift+F8 : DISABLED DEFAULT
-KEY 1 32781 1013 0		 # Main : NUM ENTER : Transport: Record
 KEY 1 82 1013 0		 # Main : R : OVERRIDE DEFAULT : Transport: Record
+KEY 9 13 1013 0		 # Main : Ctrl+ENTER : Transport: Record
+KEY 9 32781 1013 0		 # Main : Ctrl+NUM ENTER : Transport: Record
 KEY 5 13 1041 0		 # Main : Shift+ENTER : Track: Cycle track folder state
 KEY 1 13 1042 0		 # Main : ENTER : OVERRIDE DEFAULT : Track: Cycle folder collapsed state
+KEY 1 32781 1042 0		 # Main : NUM ENTER : Track: Cycle folder collapsed state
 KEY 9 82 1068 0		 # Main : Ctrl+R : OVERRIDE DEFAULT : Transport: Toggle repeat
 KEY 1 72 1134 0		 # Main : H : Transport: Tap tempo
 KEY 1 76 1135 0		 # Main : L : OVERRIDE DEFAULT : Options: Toggle locking
@@ -438,6 +440,8 @@ KEY 1 82 1013 100		 # Main (alt recording) : R : Transport: Record
 KEY 5 116 14 100		 # Main (alt recording) : Shift+F5 : Track: Toggle mute for master track
 KEY 5 117 15 100		 # Main (alt recording) : Shift+F6 : Track: Toggle solo for master track
 KEY 1 32 40044 100		 # Main (alt recording) : Space : Transport: Play/stop
+KEY 9 13 1 102		 # glob hotkey : Ctrl+ENTER : 
+KEY 9 32781 1 102		 # glob hotkey : Ctrl+NUM ENTER : 
 KEY 0 45 0 32060		 # MIDI Editor : - : DISABLED DEFAULT
 KEY 0 61 0 32060		 # MIDI Editor : = : DISABLED DEFAULT
 KEY 0 63 0 32060		 # MIDI Editor : ? : DISABLED DEFAULT

--- a/readme.md
+++ b/readme.md
@@ -297,7 +297,7 @@ SWS/FNG: Time stretch selected items (fine): Control+Alt+=
 - Edit: Redo: Control+Shift+Z
 
 #### Transport
-- Transport: Record: R, NumPadEnter
+- Transport: Record: R, Control+Enter, Control+NumPadEnter
 - Transport: Toggle repeat: Control+R
 - Transport: Increase playrate by ~6% (one semitone): Control+Shift+=
 - Transport: Decrease playrate by ~6% (one semitone): Control+Shift+-


### PR DESCRIPTION
A while ago we added NumPadEnter as an alternative way to start recording, but there are situations where that keystroke didn't pass through to the main window as intended. Adding Control modifier and making the two alternatives Global scope addresses all the situations where users might want to start recording/punch-out. We've kept the Control modifier consistent on Mac in line with other transport keys that typically stay the same, easing transition for folks who use OSARA on both platforms.