### PR TITLE
Fix build on clang 20

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -54,7 +54,7 @@ if env["PLATFORM"] == "win32":
 		# Ignore suggestions to add braces around initialization of subobjects. We might want to fix this at some point
 		"/clang:-Wno-missing-braces",
 		# Ignore deprecated literal operator in fmt
-		"/clang:-Wno-deprecated-literal-operator"
+		"/clang:-Wno-deprecated-literal-operator",
 	])
 	env.Append(CFLAGS=[
 		# Ignore warnings in WDL/win32_utf8.c, not our code


### PR DESCRIPTION
Build with Visual Studio 2026 (Clang 20) fails. This should fix that by ignoring another deprecation.
@jcsteh is there a particular reason why we're at such an old version of the fmt submodule?