### PR TITLE
strip "&" from translations on macOS, fixes #1352

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -173,6 +173,5 @@ void translateDialog(HWND dialog) {
 	// Translate dialog title.
 	translateWindow(dialog, lParam);
 	// Translate controls.
-	HWND enumRoot = dialog;
-	EnumChildWindows(enumRoot, translateWindow, lParam);
+	EnumChildWindows(dialog, translateWindow, lParam);
 }


### PR DESCRIPTION
Swell doesn't support nemonics for controls indicated by '&'. This adds entrys to the translation dictionary with the '&' chars stripped.

also add "Deutsch" to the langpack aliases because that is the name of the German translation linked from https://www.reaper.fm/langpack/