### PR TITLE
Add filter for ampersands in PO strings on macOS, fixes #1352

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <fstream>
 #include <map>
-#include <sstream>
 #include <tinygettext/dictionary.hpp>
 #include <tinygettext/po_parser.hpp>
 #include "osara.h"


### PR DESCRIPTION
fixes #1352

Swell doesn't support nemonics for controls indicated by '&'. This adds entrys to the translation dictionary with the '&' chars stripped.

also add "Deutsch" to the langpack aliases because that is the name of the German translation linked from https://www.reaper.fm/langpack/

similar to #1353 but reads and filters po file into a string and passes an `istringstream` to tinygettext.