### PR TITLE
Ship ARM64EC code in an ARM64X binary

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -67,7 +67,7 @@ if env["PLATFORM"] == "win32":
 	env.Append(LINKFLAGS='/OPT:REF')
 	if env["TARGET_ARCH"] == "arm64":
 		env.Append(CCFLAGS="/arm64EC")
-		env.Append(LINKFLAGS="/machine:arm64ec")
+		env.Append(LINKFLAGS="/machine:arm64x")
 	sources.extend((
 		"uia.cpp",
 		env.Object("win32_utf8.obj", "#include/WDL/WDL/win32_utf8.c"),


### PR DESCRIPTION
The ARm64EC version of OSARA was linked with the `/machine:arm64ec` flag. This created an ARm64EC dll that is somehow binary compatible with X64, meaning that windows <11 would try to load it.
Changed this to link with the `/machine:arm64x` flag. Basically this tells the OS that it contains both ARM64 and ARM64EC code in one binary. We however never link ARm64 native code. Much more importantly though, these binaries look like ARM64 native binaries on Windows < 11, and therefore I"m pretty sure that they will never load.
I'm tempted to merge this as is as I have tested that it still works on ARM64, though first I'd like a test from @ScottChesworth to be absolutely sure that it fixes the issue. It doesn't make sense to spam our users with updates that actually don't fix anything.

Fixes #1369 