### PR TITLE
Alternative approach to hiding unusable parameters using string matching.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -849,18 +849,7 @@ class FxParams: public ParamSource {
 			// Named config params aren't FX params; keep them visible.
 			return true;
 		}
-		const int fxParam = param - namedCount;
-		char buf[16] = {};
-		const bool success = this->_GetNamedConfigParm(
-			this->obj,
-			this->fx,
-			fmt::format("param.{}.automatable", fxParam).c_str(),
-			buf,
-			sizeof(buf));
-		if (success && buf[0] != '1') {
-			return false;
-		}
-		static const regex RE_UNNAMED_PARAM{"(?:|-|\\d{1,4} -|[P#]\\d{3}) \\(\\d+\\)"};
+		static const regex RE_UNNAMED_PARAM{"(?:|-|\\d{1,4} -|[P#]\\d{3}|(?:MIDI CC|MIDI Controller|Program Change|CC|Pitch Bend|Pitchbend|Aftertouch|Channel Pressure|MIDI State|Poly|Omni|All Notes|All Sound|Local Control|X \\(Reserved\\)|Internal|Registered Parameter Number|Non - Registered Parameter Number|Reset All Controllers|\\(MSB \\)|\\(LSB\\) ).*?) \\(\\d+\\)"};
 		smatch m;
 		regex_match(name, m, RE_UNNAMED_PARAM);
 		if (!m.empty()) {


### PR DESCRIPTION
This is based on @ScottChesworth's work in #1279, but it extends the regular expression rather than doing separate string searches. This does make the code less readable, but it means we handle all the string matching once. That said, in C++, this probably shouldn't make any difference from a performance perspective. The original code did match both at the start and the end of the string though, whereas this only matches at the start. I think if we go this path, we need to be a lot clearer about exactly what forms these strings come in. Single examples of each different type of string would be helpful.