### PR TITLE
Report frozen after track names

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1002,10 +1002,6 @@ void postGoToTrack(int command, MediaTrack* track) {
 		separate();
 		s << translate("armed");
 	}
-	if (isTrackFrozen(track)) {
-		separate();
-		s << translate("frozen");
-	}
 	if (isTrackMuted(track)) {
 		separate();
 		s << translate("muted");
@@ -1042,6 +1038,10 @@ void postGoToTrack(int command, MediaTrack* track) {
 			// There's no name and track number reporting is disabled. We report the
 			// number in lieu of the name.
 			s << trackNum;
+		}
+		if (isTrackFrozen(track)) {
+			separate();
+			s << translate("frozen");
 		}
 		if (folderDepth <0){ //end of folder
 			separate();


### PR DESCRIPTION
It's been pointed out that in a project with many frozen tracks, hearing frozen reported before each track name made navigation through the track list less productive. Given that a common scenario for having a lot of frozen tracks is to buy back some performance, it didn't seem right that we're making people move slower after they've done that, so now we report frozen after the track name.