### PR TITLE
Report recordseparate config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -783,7 +783,9 @@ The dialog contains the following options:
  Using the same example, OSARA would report only "beat 2".
 - Move relative to the play cursor for time movement commands during playback: When enabled, time movement commands such as scrubbing or moving by bar/beat will move from where you are currently playing, rather than relative to the edit cursor.
 - Report markers and regions during playback: When enabled, project markers and regions will be reported during playback as the cursor passes them.
-- Report transport state (play, record, etc.): When enabled, OSARA will report the transport state when you change it; e.g. if you begin playing or recording.
+- Report time selection start and end while playing: When enabled, start and end of time selection will be reported during playback as the cursor passes them.
+- Report transport play, pause and stop: When enabled, OSARA will report those states as you control REAPER's transport.
+- Report recording state: When enabled, OSARA will report recording starting and stopping. This can be toggled separately from other transport reports if you want to cut down verbosity.
 - Report track numbers: When enabled, OSARA will report track numbers as well as track names.
  When disabled, track numbers will not be reported except for unnamed tracks.
 - Report FX when moving to tracks/takes: When enabled, OSARA will report the names of any effects on a track or take when you move to it.

--- a/src/controlSurface.cpp
+++ b/src/controlSurface.cpp
@@ -111,7 +111,7 @@ class Surface: public IReaperControlSurface {
 		}
 		// Calculate integer based transport state
 		int TransportState = (int)play | ((int)pause << 1) | ((int)rec << 2);
-		reportTransportState(TransportState);
+		reportTransportState(0, TransportState);
 	}
 
 	void SetRepeatState(bool repeat) final {

--- a/src/controlSurface.cpp
+++ b/src/controlSurface.cpp
@@ -106,7 +106,7 @@ class Surface: public IReaperControlSurface {
 		if (play) {
 			cancelPendingMidiPreviewNotesOff();
 		}
-		int transportState = (int)play | ((int)pause << 1) | ((int)rec << 2);
+		const int transportState = (int)play | ((int)pause << 1) | ((int)rec << 2);
 		int previousTransportState = this->lastTransportState;
 		this->lastTransportState = transportState;
 		if (previousTransportState == transportState) {

--- a/src/controlSurface.cpp
+++ b/src/controlSurface.cpp
@@ -106,12 +106,16 @@ class Surface: public IReaperControlSurface {
 		if (play) {
 			cancelPendingMidiPreviewNotesOff();
 		}
+		int transportState = (int)play | ((int)pause << 1) | ((int)rec << 2);
+		int previousTransportState = this->lastTransportState;
+		this->lastTransportState = transportState;
+		if (previousTransportState == transportState) {
+			return;
+		}
 		if (this->wasCausedByCommand()) {
 			return;
 		}
-		// Calculate integer based transport state
-		int TransportState = (int)play | ((int)pause << 1) | ((int)rec << 2);
-		reportTransportState(0, TransportState);
+		reportTransportState(previousTransportState, transportState);
 	}
 
 	void SetRepeatState(bool repeat) final {
@@ -447,6 +451,7 @@ class Surface: public IReaperControlSurface {
 	const int PARAM_PAN = -3;
 	int lastParam = PARAM_NONE;
 	map<MediaTrack*, uint8_t> trackCache;
+	int lastTransportState = GetPlayState() & (1 | 2 | 4);
 	double lastPlayPos = 0;
 	int lastMarker = -1;
 	int lastRegion = -1;

--- a/src/osara.h
+++ b/src/osara.h
@@ -369,7 +369,7 @@ extern CComPtr<IAccPropServices> accPropServices;
 bool isClassName(HWND hwnd, std::string className);
 
 extern bool isHandlingCommand;
-void reportTransportState(int state);
+void reportTransportState(int before, int after);
 void reportRepeat(bool repeat);
 void postGoToTrack(int command, MediaTrack* track);
 void formatPan(double pan, std::ostringstream& output);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1956,7 +1956,8 @@ void reportTransportState(int before, int after) {
 	} else if (after & 1 && (after & 4) == 0 && (settings::reportTransport 
 			|| (settings::reportRecord && before & 4))) {
 		s << translate("play");
-	} else if (settings::reportTransport || (settings::reportRecord && before & 4)) {
+	} else if ((after & (1 | 2 | 4)) == 0 &&
+			(settings::reportTransport || (settings::reportRecord && before & 4))) {
 		s << translate("stop");
 	}
 	outputMessage(s);

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1943,19 +1943,23 @@ void postToggleMasterTrackVisible(int command) {
 void reportTransportState(int before, int after) {
 	bool repeat = GetToggleCommandState(1068); // Transport: Toggle repeat
 	ostringstream s;
+	// REAPER play state bits: 1 = playing, 2 = paused, 4 = recording.
 	if (after & 2 && (settings::reportTransport 
 			|| (settings::reportRecord && before & 4))) {
 		s << translate("pause");
+	// Recording also sets the playing bit, so handle record before play.
 	} else if (after & 4 && repeat && settings::reportRecord) {
 		s << translate("record") << ", " << translate("repeat on");
 	} else if (after & 4 && settings::reportRecord) {
 		s << translate("record");
+	// Only report play here if recording is not active.
 	} else if (after & 1 && (after & 4) == 0 && repeat && (settings::reportTransport 
 			|| (settings::reportRecord && before & 4))) {
 		s << translate("play") << ", " << translate("repeat on");
 	} else if (after & 1 && (after & 4) == 0 && (settings::reportTransport 
 			|| (settings::reportRecord && before & 4))) {
 		s << translate("play");
+	// If none of the transport bits are set, REAPER is stopped.
 	} else if ((after & (1 | 2 | 4)) == 0 &&
 			(settings::reportTransport || (settings::reportRecord && before & 4))) {
 		s << translate("stop");

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -5921,6 +5921,7 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 1016}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Stop
 	{MAIN_SECTION, {{0, 0, 1013}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Record
 	{MAIN_SECTION, {{0, 0, 1007}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play
+	{MAIN_SECTION, {DEFACCEL, nullptr}, "_XENAKIOS_TIMERTEST1", cmdChangeTransportState}, // Xenakios/SWS: Play selected items once                                                                                
 	{MIDI_EDITOR_SECTION, {{0, 0, 40036}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to start of file
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40036}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to start of file
 	{MIDI_EDITOR_SECTION, {{0, 0, 40037}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to end of file

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1940,29 +1940,26 @@ void postToggleMasterTrackVisible(int command) {
 		translate("master track hidden"));
 }
 
-void reportTransportState(int state) {
+void reportTransportState(int before, int after) {
 	bool repeat = GetToggleCommandState(1068); // Transport: Toggle repeat
 	ostringstream s;
-	if (!settings::reportTransport)
-		return;
-	if (state & 2) {
+	if (after & 2 && (settings::reportTransport 
+			|| (settings::reportRecord && before & 4))) {
 		s << translate("pause");
-	} else if (state & 4 && repeat == true) {
+	} else if (after & 4 && repeat && settings::reportRecord) {
 		s << translate("record") << ", " << translate("repeat on");
-	} else if (state & 4) {
+	} else if (after & 4 && settings::reportRecord) {
 		s << translate("record");
-	} else if (state & 1 && repeat == true) {
+	} else if (after & 1 && (after & 4) == 0 && repeat && (settings::reportTransport 
+			|| (settings::reportRecord && before & 4))) {
 		s << translate("play") << ", " << translate("repeat on");
-	} else if (state & 1) {
+	} else if (after & 1 && (after & 4) == 0 && (settings::reportTransport 
+			|| (settings::reportRecord && before & 4))) {
 		s << translate("play");
-	} else {
+	} else if (settings::reportTransport || (settings::reportRecord && before & 4)) {
 		s << translate("stop");
 	}
 	outputMessage(s);
-}
-
-void postChangeTransportState(int command) {
-	reportTransportState(GetPlayState());
 }
 
 void postSelectMultipleItems(int command) {
@@ -2876,13 +2873,6 @@ PostCommand POST_COMMANDS[] = {
 	{40293, postTrackIo}, // Track: View I/O for current track
 	{40364, postToggleMetronome}, // Options: Toggle metronome
 	{40075, postToggleMasterTrackVisible}, // View: Toggle master track visible
-	{1007, postChangeTransportState}, // Transport: Play
-	{40044, postChangeTransportState}, // Transport: Play/stop
-	{40073, postChangeTransportState}, // Transport: Play/pause
-	{40328, postChangeTransportState}, // Transport: Play/stop (move edit cursor on stop)
-	{40317, postChangeTransportState}, // Transport: Play (skip time selection)
-	{1016, postChangeTransportState}, // Transport: Stop
-	{1013, postChangeTransportState}, // Transport: Record
 	{40718, postSelectMultipleItems}, // Item: Select all items on selected tracks in current time selection
 	{40421, postSelectMultipleItems}, // Item: Select all items in track
 	{40034, postSelectMultipleItems}, // Item grouping: Select all items in groups
@@ -3099,7 +3089,6 @@ PostCustomCommand POST_CUSTOM_COMMANDS[] = {
 	{"_XENAKIOS_NUDGEITEMVOLUP", postChangeItemVolume}, // Xenakios/SWS: Nudge item volume up
 	{"_FNG_RATE_101", postChangeItemRate}, // SWS/FNG: Time compress selected items (fine)
 {"_FNG_RATE_1_101", postChangeItemRate}, // SWS/FNG: Time stretch selected items (fine)
-{"_XENAKIOS_TIMERTEST1", postChangeTransportState}, // Xenakios/SWS: Play selected items once
 {"_FNG_QUANTIZE_TO_GRID", postQuantize}, // SWS/FNG: Quantize item positions and MIDI note positions to grid
 {"_XENAKIOS_MOVECUR10PIX_LEFT", postCursorMovementScrub}, // Xenakios/SWS: Move cursor left 10 pixels
 {"_XENAKIOS_MOVECUR10PIX_RIGHT", postCursorMovementScrub}, // Xenakios/SWS: Move cursor right 10 pixels
@@ -5787,6 +5776,13 @@ void cmdShowPeakAndLoudnessMenu(Command* command) {
 	}
 }
 
+void cmdChangeTransportState(Command* command) {
+	int before = GetPlayState();
+	Main_OnCommand(command->gaccel.accel.cmd, 0);
+	int after = GetPlayState();
+	reportTransportState(before, after);
+}
+
 #define DEFACCEL {0, 0, 0}
 
 // REAPER or extension commands that we want to intercept.
@@ -5913,6 +5909,13 @@ Command COMMANDS[] = {
 	{MAIN_SECTION, {{0, 0, 42089}, nullptr}, nullptr, cmdGlueAutoItems}, // Envelope: Glue automation items
 	{MAIN_SECTION, {{0, 0, 40069}, nullptr}, nullptr, cmdJumpToTime}, // View: Jump (go) to time window
 	{MAIN_SECTION, {{0, 0, 50125}, nullptr}, nullptr, cmdVideoWindowVisibility}, // Video: Show/hide video window
+	{MAIN_SECTION, {{0, 0, 40044}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play/stop
+	{MAIN_SECTION, {{0, 0, 40073}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play/pause
+	{MAIN_SECTION, {{0, 0, 40328}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play/stop (move edit cursor on stop)
+	{MAIN_SECTION, {{0, 0, 40317}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play (skip time selection)
+	{MAIN_SECTION, {{0, 0, 1016}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Stop
+	{MAIN_SECTION, {{0, 0, 1013}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Record
+	{MAIN_SECTION, {{0, 0, 1007}, nullptr}, nullptr, cmdChangeTransportState}, // Transport: Play
 	{MIDI_EDITOR_SECTION, {{0, 0, 40036}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to start of file
 	{MIDI_EVENT_LIST_SECTION, {{0, 0, 40036}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to start of file
 	{MIDI_EDITOR_SECTION, {{0, 0, 40037}, nullptr}, nullptr, cmdMidiMoveCursor}, // View: Go to end of file

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1961,9 +1961,9 @@ void reportTransportState(int before, int after) {
 	} else if (after & 4) {
 		s << translate("record");
 	// Only report play here if recording is not active.
-	} else if (after & 1 && (after & 4) == 0 && repeat) {
+	} else if (after & 1 && repeat) {
 		s << translate("play") << ", " << translate("repeat on");
-	} else if (after & 1 && (after & 4) == 0) {
+	} else if (after & 1) {
 		s << translate("play");
 	// If none of the transport bits are set, REAPER is stopped.
 	} else if ((after & (1 | 2 | 4)) == 0) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1941,27 +1941,32 @@ void postToggleMasterTrackVisible(int command) {
 }
 
 void reportTransportState(int before, int after) {
+	bool shouldReport = settings::reportTransport;
+	if (before & 4 || after & 4) {
+		// We are recording now, or we were recording and just stopped.
+		// That means this change is related to recording.
+		shouldReport = settings::reportRecord;
+	}
+	if (!shouldReport) {
+		return;
+	}
 	bool repeat = GetToggleCommandState(1068); // Transport: Toggle repeat
 	ostringstream s;
 	// REAPER play state bits: 1 = playing, 2 = paused, 4 = recording.
-	if (after & 2 && (settings::reportTransport 
-			|| (settings::reportRecord && before & 4))) {
+	if (after & 2) {
 		s << translate("pause");
 	// Recording also sets the playing bit, so handle record before play.
-	} else if (after & 4 && repeat && settings::reportRecord) {
+	} else if (after & 4 && repeat) {
 		s << translate("record") << ", " << translate("repeat on");
-	} else if (after & 4 && settings::reportRecord) {
+	} else if (after & 4) {
 		s << translate("record");
 	// Only report play here if recording is not active.
-	} else if (after & 1 && (after & 4) == 0 && repeat && (settings::reportTransport 
-			|| (settings::reportRecord && before & 4))) {
+	} else if (after & 1 && (after & 4) == 0 && repeat) {
 		s << translate("play") << ", " << translate("repeat on");
-	} else if (after & 1 && (after & 4) == 0 && (settings::reportTransport 
-			|| (settings::reportRecord && before & 4))) {
+	} else if (after & 1 && (after & 4) == 0) {
 		s << translate("play");
 	// If none of the transport bits are set, REAPER is stopped.
-	} else if ((after & (1 | 2 | 4)) == 0 &&
-			(settings::reportTransport || (settings::reportRecord && before & 4))) {
+	} else if ((after & (1 | 2 | 4)) == 0) {
 		s << translate("stop");
 	}
 	outputMessage(s);

--- a/src/settings.h
+++ b/src/settings.h
@@ -33,10 +33,13 @@ BoolSetting(reportTimeSelectionWhilePlaying, MAIN_SECTION,
 	"Report time se&lection start and end while playing",
 	false)
 BoolSetting(reportTransport, MAIN_SECTION,
-	"Report &transport state (play, record, etc.)",
+	"Report &transport play, pause and stop",
+	true)
+BoolSetting(reportRecord, MAIN_SECTION,
+	"Report &recording state",
 	true)
 BoolSetting(reportTrackNumbers, MAIN_SECTION,
-	"&Report track numbers",
+	"Report tr&ack numbers",
 	true)
 BoolSetting(reportFx, MAIN_SECTION,
 	"Report &FX when moving to tracks/takes",


### PR DESCRIPTION
We've had a handful of requests over the years for report recording to be a dedicated setting. It's like a speaky red light, a safety check that you might want to keep on even though you're confident enough with keystrokes that you don't want play states talking all day long.