### PR TITLE
Sign the Windows dlls inside the installer.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,23 @@ jobs:
         # We need php for swell_resgen.
         run: brew install php
       - name: build
-        run: scons "publisher=${{ env.publisher }}" version=${{ env.version }}
-      - name: sign Windows
+        run: scons build "publisher=${{ env.publisher }}" version=${{ env.version }}
+      - name: sign Windows build
+        if: ${{ github.event_name == 'push' && runner.os == 'Windows' }}
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.AZURE_SIGNING_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_SIGNING_CERT_NAME }}
+          files-folder: ${{ github.workspace }}\build
+          files-folder-recurse: true
+          files-folder-filter: dll
+      - name: installer
+        run: scons installer "publisher=${{ env.publisher }}" version=${{ env.version }}
+      - name: sign Windows installer
         if: ${{ github.event_name == 'push' && runner.os == 'Windows' }}
         uses: azure/trusted-signing-action@v0
         with:

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -151,4 +151,9 @@ addExternalSources(
 env.SharedLibrary(
 	target="reaper_osara%s" % env["libSuffix"],
 	source=sources, LIBS=libs,
+	# On Windows, scons thinks that creating a .lib file always creates a .exp
+	# file, but it doesn't for OSARA. This results in rebuilding the dll every
+	# time scons is run, since scons can't find the .exp. Work around this by
+	# disabling import lib generation.
+	no_import_lib=1
 )


### PR DESCRIPTION
Previously, we only signed the installer itself.
Signing the dlls might reduce cases where Windows decides to block the dll after OSARA is installed.