### PR TITLE
Fix build with clang 22

### DIFF
--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -45,6 +45,8 @@ if env["PLATFORM"] == "win32":
 	if env["TARGET_ARCH"] != "arm64":
 		env["LINK"] = "lld-link"
 	env.Append(CCFLAGS=[
+		# Explicitly set 32/64-bit so clang-cl doesn't default to x64 regardless of MSVC env.
+		"-m32" if env["TARGET_ARCH"] == "x86" else "-m64",
 		"/W3",
 		"/WX",
 		# Clang warns about unused functions in WDL


### PR DESCRIPTION
The Visual Studio 2026 June update ships with clang 22, which no longer
infers the target architecture from the MSVC environment — it always defaults
to x64, causing x86 objects to be compiled as x64 while the linker found x86
libs, resulting in machine type conflicts.

Fix: pass `-m32`/`-m64` explicitly to clang-cl (same approach used in NVDA's
build system). There is no MSVC cl.exe-native equivalent since cl.exe bakes
architecture into which executable you run.