### PR TITLE
Use lld-link for arm64ec builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1111,7 +1111,7 @@ To build OSARA, you will need:
 	See the note about submodules in the previous section.
 
 #### Windows
-- [Build Tools for Visual Studio 2026](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026)
+- [Build Tools for Visual Studio 2026](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026), version 18.7.0 or newer.
 
 	Visual Studio 2026 Community/Professional/Enterprise is also supported.
 	However, Preview versions of Visual Studio will not be detected and cannot be used.
@@ -1124,7 +1124,7 @@ To build OSARA, you will need:
 			- MSVC Build Tools for x64/x86 (Latest)
 			- C++ ATL for x64/x86 (Latest MSVC)
 			- C++ Clang tools for Windows
-			- Windows 11 SDK (10.0.26100.xxx)
+			- Windows 11 SDK (10.0.28000.xxxx)
 	* on the Individual components tab:
 		- In the Compilers, build tools, and runtimes grouping:
 			- MSVC Build Tools for ARM64/ARM64EC (Latest)

--- a/src/archBuild_sconscript
+++ b/src/archBuild_sconscript
@@ -41,9 +41,7 @@ sources = [
 if env["PLATFORM"] == "win32":
 	# On Windows, OSARA is build with LLVM to have a toolchain that's closer to what's used on Mac
 	env["CC"] = "clang-cl"
-	# For ARM64EC, we can't yet link with LLVM due to undefined symbol: __sanitizer_annotate_contiguous_container
-	if env["TARGET_ARCH"] != "arm64":
-		env["LINK"] = "lld-link"
+	env["LINK"] = "lld-link"
 	env.Append(CCFLAGS=[
 		# Explicitly set 32/64-bit so clang-cl doesn't default to x64 regardless of MSVC env.
 		"-m32" if env["TARGET_ARCH"] == "x86" else "-m64",


### PR DESCRIPTION
The `__sanitizer_annotate_contiguous_container` undefined symbol that
previously prevented lld-link from being used for arm64ec is resolved in Visual Studio, starting from the June update, since it uses LLVM  22.
We can merge this as soon as CI is at the june update, however this would break for people on Visual Studio <= 2026 june update.

@jcsteh Would you like to keep backwards compatibility or should we merge this as soon as github updated their runner?