### PR TITLE
FX Parameters dialog: Tweak detection of unnamed and potentially unusable parameters.

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -866,8 +866,8 @@ class FxParams: public ParamSource {
 			"|-"
 			// Example: "1234 -"
 			R"(|\d{1,4} -)"
-			// Example: "P123" or "#123"
-			R"(|[P#]\d{3})"
+			// Example: "123" or "P123" or "#1234"
+			R"(|[P#]?\d{3,4})"
 			// Any one of several strings...
 			"|(?:MIDI CC|MIDI Controller|Program Change|CC|Pitch Bend|Pitchbend"
 			"|Aftertouch|Channel Pressure|MIDI State|Poly|Omni|All Notes|All Sound"

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -783,6 +783,7 @@ class FxParams: public ParamSource {
 	bool (*_FormatParamValue)(ReaperObj*, int, int, double, char*, int);
 	bool (*_GetNamedConfigParm)(ReaperObj*, int, const char*, char*, int);
 	bool (*_SetNamedConfigParm)(ReaperObj*, int, const char*, const char*);
+	void (*_GetParamSectionName)(ReaperObj*, int, int, char*, int);
 
 	void initNamedConfigParams();
 
@@ -803,6 +804,8 @@ class FxParams: public ParamSource {
 			(apiPrefix + "_GetNamedConfigParm").c_str());
 		*(void**)&this->_SetNamedConfigParm = plugin_getapi(
 			(apiPrefix + "_SetNamedConfigParm").c_str());
+		*(void**)&this->_GetParamSectionName = plugin_getapi(
+			(apiPrefix + "_GetParamSectionName").c_str());
 		if (fx >= 0) {
 			this->initNamedConfigParams();
 		}
@@ -848,6 +851,14 @@ class FxParams: public ParamSource {
 		if (param < namedCount) {
 			// Named config params aren't FX params; keep them visible.
 			return true;
+		}
+		if (this->_GetParamSectionName) {
+			char section[100];
+			this->_GetParamSectionName(this->obj, this->fx, param, section,
+				sizeof(section));
+			if (strcmp(section, "MIDI") == 0) {
+				return false;
+			}
 		}
 		static const regex RE_UNNAMED_PARAM{
 			"(?:"

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -868,13 +868,6 @@ class FxParams: public ParamSource {
 			R"(|\d{1,4} -)"
 			// Example: "123" or "P123" or "#1234"
 			R"(|[P#]?\d{3,4})"
-			// Any one of several strings...
-			"|(?:MIDI CC|MIDI Controller|Program Change|CC|Pitch Bend|Pitchbend"
-			"|Aftertouch|Channel Pressure|MIDI State|Poly|Omni|All Notes|All Sound"
-			R"(|Local Control|X \(Reserved\)|Internal|Registered Parameter Number)"
-			R"(|Non - Registered Parameter Number|Reset All Controllers|\(MSB \)|\(LSB\))"
-			// followed by any number of other characters; e.g. "MIDI CC 2|15"
-			" ).*?"
 			// OSARA appends a number in parentheses to all parameter names. See the
 			// getParamName function above.
 			R"() \(\d+\))"
@@ -883,6 +876,26 @@ class FxParams: public ParamSource {
 		regex_match(name, m, RE_UNNAMED_PARAM);
 		if (!m.empty()) {
 			return false;
+		}
+		char automatable[2] = "";
+		this->_GetNamedConfigParm(this->obj, this->fx,
+			format("param.{}.automatable", param).c_str(),
+			automatable, sizeof(automatable));
+		if (automatable[0] == '0') {
+			// Check for some strings only for non-automatable parameters.
+			static const regex RE_UNNAMED_NONAUTOMATABLE_PARAM{
+				// Any one of several strings...
+				"(?:MIDI CC|MIDI Controller|Program Change|CC|Pitch Bend|Pitchbend"
+				"|Aftertouch|Channel Pressure|MIDI State|Poly|Omni|All Notes|All Sound"
+				R"(|Local Control|X \(Reserved\)|Internal|Registered Parameter Number)"
+				R"(|Non - Registered Parameter Number|Reset All Controllers|\(MSB \)|\(LSB\))"
+				// followed by any number of other characters; e.g. "MIDI CC 2|15"
+				") .*"
+			};
+			regex_match(name, m, RE_UNNAMED_NONAUTOMATABLE_PARAM);
+			if (!m.empty()) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -867,8 +867,8 @@ class FxParams: public ParamSource {
 			"|unnamed"
 			// Example: "1234 -"
 			R"(|\d{1,4} -)"
-			// Example: "12" or "P123" or "#1234"
-			R"(|[P#]?\d{2,4})"
+			// Example: "1" or "P123" or "#1234"
+			R"(|[P#]?\d{1,4})"
 			// Example: "Spec 1000"
 			R"(|Spec \d+)"
 			// OSARA appends a number in parentheses to all parameter names. See the

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -864,10 +864,13 @@ class FxParams: public ParamSource {
 			"(?:"
 			// Empty string or "-"
 			"|-"
+			"|unnamed"
 			// Example: "1234 -"
 			R"(|\d{1,4} -)"
-			// Example: "123" or "P123" or "#1234"
-			R"(|[P#]?\d{3,4})"
+			// Example: "12" or "P123" or "#1234"
+			R"(|[P#]?\d{2,4})"
+			// Example: "Spec 1000"
+			R"(|Spec \d+)"
 			// OSARA appends a number in parentheses to all parameter names. See the
 			// getParamName function above.
 			R"() \(\d+\))"


### PR DESCRIPTION
1. Treat any parameters in a section named "MIDI" as unusable. This filters out parameters like "Control 64"" in Waves plugins.
2. Treat parameters named, for example, "#1234" or "123" as unusable. This filters out parameters like "#1000" in Kontakt or "511" in Keyscape.
3. Only treat CC, etc. parameter names as unusable if the parameter is also non-automatable.

Fixes #1401.