### PR TITLE
Suppress automatic reporting while a ReaScript action runs

### DIFF
--- a/src/exports.cpp
+++ b/src/exports.cpp
@@ -14,7 +14,7 @@
 // The _vararg_ version is needed for ReaScript.
 
 void osara_outputMessage(const char* message) {
-	outputMessage(message);
+	outputMessageFromApi(message);
 }
 void* _vararg_osara_outputMessage(void** args, int nArgs) {
 	osara_outputMessage((const char*)args[0]);
@@ -23,6 +23,14 @@ void* _vararg_osara_outputMessage(void** args, int nArgs) {
 
 bool osara_isShortcutHelpEnabled() {
 	return isShortcutHelpEnabled;
+}
+
+void osara_suppressAutomaticMessages(bool suppress) {
+	setAutomaticMessageSuppression(suppress);
+}
+void* _vararg_osara_suppressAutomaticMessages(void** args, int nArgs) {
+	osara_suppressAutomaticMessages((uintptr_t)args[0] != 0);
+	return nullptr;
 }
 
 void osara_getVersion(char* versionOut, int versionOut_sz) {
@@ -46,6 +54,18 @@ void registerExports(reaper_plugin_info_t* rec) {
 	rec->Register("API_osara_isShortcutHelpEnabled",
 		(void*)osara_isShortcutHelpEnabled);
 	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
+	rec->Register("API_osara_suppressAutomaticMessages",
+		(void*)osara_suppressAutomaticMessages);
+	rec->Register("APIvararg_osara_suppressAutomaticMessages",
+		(void*)_vararg_osara_suppressAutomaticMessages);
+	rec->Register("APIdef_osara_suppressAutomaticMessages",
+		(void*)"void\0bool\0suppress\0"
+		"Suppress or resume OSARA's automatic reporting of state changes (e.g. "
+		"track mute/solo/arm, volume, pan, toggle actions).\n"
+		"Call with true before a sequence of actions or API calls you want to "
+		"perform quietly, and false when done. Calls may be nested; make sure "
+		"every true call is matched by a false call.\n"
+		"This has no effect on messages sent explicitly via osara_outputMessage.");
 	rec->Register("APIvararg_osara_getVersion",
 		(void*)_vararg_osara_getVersion);
 	rec->Register("APIdef_osara_getVersion",

--- a/src/osara.h
+++ b/src/osara.h
@@ -278,6 +278,8 @@ extern int lastCommand;
 bool shouldReportTimeMovement() ;
 void outputMessage(const std::string& message, bool interrupt = true);
 void outputMessage(std::ostringstream& message, bool interrupt = true);
+void outputMessageFromApi(const std::string& message, bool interrupt = true);
+void setAutomaticMessageSuppression(bool suppress);
 
 // Call a function or lambda (even a lambda with capture) asynchronously after
 // the specified number of ms. The function must take no parameters and return

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -137,9 +137,14 @@ void _outputMessage(const string& message, bool interrupt) {
 #endif // _WIN32
 
 bool muteNextMessage = false;
+int automaticMessageSuppressionDepth = 0;
+
 void outputMessage(const string& message, bool interrupt) {
 	if(muteNextMessage && isHandlingCommand){
 		muteNextMessage = false;
+		return;
+	}
+	if (automaticMessageSuppressionDepth > 0) {
 		return;
 	}
 	_outputMessage(message, interrupt);
@@ -147,6 +152,22 @@ void outputMessage(const string& message, bool interrupt) {
 
 void outputMessage(ostringstream& message, bool interrupt) {
 	outputMessage(message.str(), interrupt);
+}
+
+void outputMessageFromApi(const string& message, bool interrupt) {
+	if(muteNextMessage && isHandlingCommand){
+		muteNextMessage = false;
+		return;
+	}
+	_outputMessage(message, interrupt);
+}
+
+void setAutomaticMessageSuppression(bool suppress) {
+	if (suppress) {
+		++automaticMessageSuppressionDepth;
+	} else if (automaticMessageSuppressionDepth > 0) {
+		--automaticMessageSuppressionDepth;
+	}
 }
 
 bool CallLater::cancel() {


### PR DESCRIPTION
**Problem:** Scripts that drive a sequence of actions/API calls currently get OSARA's full automatic narration for every recognized state change along the way — toggle messages, mute/solo/arm/volume/pan reports, etc. This competes with and buries messages a script reports explicitly via `osara_outputMessage`.

**Change:** Adds a new exported ReaScript API, `osara_suppressAutomaticMessages(bool suppress)`, that a script can call to pause OSARA's automatic reporting around a section it wants to handle quietly itself, e.g.:

```lua
reaper.osara_suppressAutomaticMessages(true)
-- ... a bunch of Main_OnCommand calls / track changes the script wants to be quiet about ...
reaper.osara_suppressAutomaticMessages(false)
reaper.osara_outputMessage("Setup complete")
```

Calls nest (each true increments a counter, each false decrements it), so it's safe even if the calling script itself calls other scripts/actions that also toggle suppression. `osara_outputMessage` is never affected by this — explicit messages always get through.

**Design notes:**
- This is purely opt-in. Nothing changes for any existing script or action unless it explicitly calls the new function, so there's no risk to scripts that rely on OSARA's existing automatic narration today.
- Implementation gates the single internal `outputMessage()` function that nearly all of OSARA's own reporting funnels through. `osara_outputMessage` now calls a new `outputMessageFromApi()` that bypasses the suppression gate (but still respects the existing `muteNextMessage` one-shot mute).
- No changes to `handleCommand`/`handleToggleCommand` or any other action-dispatch logic.

**Testing:** Not yet built on Windows/Mac — happy to do so, or for a maintainer to sanity-check the approach first.