### PR TITLE
Add the ability for ReaScripts to suppress messages from OSARA while they run.

### DIFF
--- a/src/exports.cpp
+++ b/src/exports.cpp
@@ -2,7 +2,7 @@
  * OSARA: Open Source Accessibility for the REAPER Application
  * Exported API functions code
  * Exports functions to be called by REAPER extensions and scripts.
- * Copyright 2020-2023 James Teh
+ * Copyright 2020-2026 James Teh
  * License: GNU General Public License version 2.0
  */
 
@@ -14,7 +14,7 @@
 // The _vararg_ version is needed for ReaScript.
 
 void osara_outputMessage(const char* message) {
-	outputMessage(message);
+	outputMessageFromApi(message);
 }
 void* _vararg_osara_outputMessage(void** args, int nArgs) {
 	osara_outputMessage((const char*)args[0]);
@@ -33,6 +33,14 @@ void* _vararg_osara_getVersion(void** args, int nArgs) {
 	return nullptr;
 }
 
+void osara_suppressMessagesFromOsara() {
+	suppressOsaraMessages();
+}
+void* _vararg_osara_suppressMessagesFromOsara(void** args, int nArgs) {
+	osara_suppressMessagesFromOsara();
+	return nullptr;
+}
+
 void registerExports(reaper_plugin_info_t* rec) {
 	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
 	rec->Register("APIvararg_osara_outputMessage",
@@ -45,7 +53,6 @@ void registerExports(reaper_plugin_info_t* rec) {
 		"focus such as list boxes and trees.");
 	rec->Register("API_osara_isShortcutHelpEnabled",
 		(void*)osara_isShortcutHelpEnabled);
-	rec->Register("API_osara_outputMessage", (void*)osara_outputMessage);
 	rec->Register("APIvararg_osara_getVersion",
 		(void*)_vararg_osara_getVersion);
 	rec->Register("APIdef_osara_getVersion",
@@ -53,4 +60,11 @@ void registerExports(reaper_plugin_info_t* rec) {
 		"Get the version of OSARA.\n"
 		"This will be in the form: year.month.day.build,commit\n"
 		"For example: 2024.3.6.1332,13560ef7");
+	rec->Register("API_osara_suppressMessagesFromOsara",
+		(void*)osara_suppressMessagesFromOsara);
+	rec->Register("APIvararg_osara_suppressMessagesFromOsara",
+		(void*)_vararg_osara_suppressMessagesFromOsara);
+	rec->Register("APIdef_osara_suppressMessagesFromOsara",
+		(void*)"void\0\0\0"
+		"Suppress reporting of messages from OSARA itself in response to actions or control surface changes.\nThis should be called before a sequence of actions you want to perform quietly. The suppression will be disabled after your script completes. This has no effect on messages sent explicitly via osara_outputMessage.");
 }

--- a/src/osara.h
+++ b/src/osara.h
@@ -278,6 +278,8 @@ extern int lastCommand;
 bool shouldReportTimeMovement() ;
 void outputMessage(const std::string& message, bool interrupt = true);
 void outputMessage(std::ostringstream& message, bool interrupt = true);
+void outputMessageFromApi(const std::string& message);
+void suppressOsaraMessages();
 
 // Call a function or lambda (even a lambda with capture) asynchronously after
 // the specified number of ms. The function must take no parameters and return

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -137,9 +137,14 @@ void _outputMessage(const string& message, bool interrupt) {
 #endif // _WIN32
 
 bool muteNextMessage = false;
+bool shouldSuppressOsaraMessages = false;
+
 void outputMessage(const string& message, bool interrupt) {
 	if(muteNextMessage && isHandlingCommand){
 		muteNextMessage = false;
+		return;
+	}
+	if (shouldSuppressOsaraMessages) {
 		return;
 	}
 	_outputMessage(message, interrupt);
@@ -147,6 +152,30 @@ void outputMessage(const string& message, bool interrupt) {
 
 void outputMessage(ostringstream& message, bool interrupt) {
 	outputMessage(message.str(), interrupt);
+}
+
+void outputMessageFromApi(const string& message) {
+	if(muteNextMessage && isHandlingCommand){
+		muteNextMessage = false;
+		return;
+	}
+	_outputMessage(message, true);
+}
+
+void suppressOsaraMessages() {
+	shouldSuppressOsaraMessages = true;
+	// Disable suppression once this script finishes; i.e. when REAPER returns to
+	// its main loop.
+	static void (*disableSuppression)() = [] {
+		if (!IsWindowEnabled(mainHwnd)) {
+			// This CallLater ran within a blocking modal dialog; the script is still
+			// running. Reschedule the CallLater.
+			CallLater(disableSuppression, 50);
+			return;
+		}
+		shouldSuppressOsaraMessages = false;
+	};
+	CallLater(disableSuppression, 0);
 }
 
 bool CallLater::cancel() {


### PR DESCRIPTION
This is an alternative to #1405. Once osara_suppressMessagesFromOsara() is called, messages are suppressed until the script finishes, taking modal dialogs into account.

This is completely untested at this point.

CC @chmaha.