### PR TITLE
Fix send enumeration with hardware outputs

### DIFF
--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -1605,13 +1605,32 @@ class TrackParams: public ReaperObjParamSource {
 	template<int category>
 	void addSendParams(const char* trackParam) {
 		int count = GetTrackNumSends(track, category);
+		// Since REAPER 7.75, the category 0 (sends) index space used by
+		// GetSetTrackSendInfo also includes hardware outputs, ordered before the
+		// real sends to match the routing UI. GetTrackNumSends(track, 0), however,
+		// still returns only the number of real sends. We therefore walk the index
+		// space, skipping hardware outputs (which have no destination track and are
+		// enumerated separately as category 1 below), until we've found every send.
+		// On REAPER versions before 7.75, category 0 contains no hardware outputs,
+		// so this behaves like a simple 0..count iteration.
+		int maxIndex = count;
+		if constexpr (category == 0) {
+			maxIndex += GetTrackNumSends(track, 1);
+		}
 		string lastTarget;
 		int sameTargetCount = 1;
-		for (int i = 0; i < count; ++i) {
+		for (int i = 0, found = 0; i < maxIndex && found < count; ++i) {
 			string target;
 			if (trackParam) {
 				// Send or receive.
 				MediaTrack* sendTrack = (MediaTrack*)GetSetTrackSendInfo(this->track, category, i, trackParam, nullptr);
+				if constexpr (category == 0) {
+					if (!sendTrack) {
+						// A hardware output occupying a slot in the sends index space.
+						// Skip it here; it is enumerated as a hardware output below.
+						continue;
+					}
+				}
 				auto trackNum = (int)(size_t)GetSetMediaTrackInfo(sendTrack,
 					"IP_TRACKNUMBER", nullptr);
 				char* trackName = (char*)GetSetMediaTrackInfo(sendTrack, "P_NAME", nullptr);
@@ -1723,6 +1742,7 @@ class TrackParams: public ReaperObjParamSource {
 			this->params.push_back(make_unique<TrackSendParamProvider>(
 				paramName(translate("send type")), this->track, category, i, "I_SENDMODE",
 				SendTypeParam::make));
+			++found;
 		}
 	}
 

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -1435,11 +1435,6 @@ class AudioChannelParam:  public ReaperObjParam {
 	private:
 	Param::AfterOption addChannels(int count) {
 		MediaTrack* track = this->getTargetTrack();
-		if (!track) {
-			// No target track (e.g. a hardware output, or a send REAPER reports with
-			// no destination track). There's nothing to add channels to.
-			return Param::AfterOption::nothing;
-		}
 		int channels = *(int*)GetSetMediaTrackInfo(track, "I_NCHAN", nullptr);
 		channels += count;
 		GetSetMediaTrackInfo(track, "I_NCHAN", (void*)&channels);
@@ -1453,21 +1448,6 @@ class SourceAudioChannelParam: public AudioChannelParam {
 			AudioChannelParam(provider) {
 		options.push_back({translate_ctxt("audio channel", "none"), -1});
 		MediaTrack* srcTrack = this->getTargetTrack();
-		if (!srcTrack) {
-			// No source track. We don't know how many source channels there are, so
-			// just expose the current setting alongside "none".
-			int src = *(int*)provider.getSetValue(nullptr);
-			if (src != -1) {
-				if (src & MONO_FLAG) {
-					this->options.push_back({fmt::format("{}", (src & ~MONO_FLAG) + 1), src});
-				} else {
-					// Multi-channel, but we don't know how many.
-					this->options.push_back({fmt::format("{}-", src + 1), src});
-				}
-			}
-			this->finishOptions();
-			return;
-		}
 		int channels = *(int*)GetSetMediaTrackInfo(srcTrack, "I_NCHAN", nullptr);
 		this->addMonoOptions(channels);
 		this->addStereoOptions(channels);
@@ -1500,11 +1480,9 @@ class DestAudioChannelParam:  public AudioChannelParam {
 		} else if (srcChans > 1) {
 			srcChans *= 2;
 		}
-		if (!dstTrack || srcChans == -1) {
-			// If there's no destination track (e.g. a hardware output, or a send
-			// REAPER reports with no destination track), or no source audio channel
-			// is set, we don't know how many destination channels there are. Just
-			// expose the current setting.
+		if (srcChans == -1) {
+			// If no source audio channel is set, we don't know how many destination
+			// channels there are. Just expose the current setting.
 			int dest = *(int*)provider.getSetValue(nullptr);
 			if (dest & MONO_FLAG) {
 				this->options.push_back({fmt::format("{}", (dest & ~MONO_FLAG) + 1), dest});
@@ -1606,13 +1584,15 @@ class TrackParams: public ReaperObjParamSource {
 	void addSendParams(const char* trackParam) {
 		int count = GetTrackNumSends(track, category);
 		// Since REAPER 7.75, the category 0 (sends) index space used by
-		// GetSetTrackSendInfo also includes hardware outputs, ordered before the
-		// real sends to match the routing UI. GetTrackNumSends(track, 0), however,
-		// still returns only the number of real sends. We therefore walk the index
-		// space, skipping hardware outputs (which have no destination track and are
-		// enumerated separately as category 1 below), until we've found every send.
-		// On REAPER versions before 7.75, category 0 contains no hardware outputs,
-		// so this behaves like a simple 0..count iteration.
+		// GetSetTrackSendInfo also includes hardware outputs; the routing UI orders
+		// these before the real sends. GetTrackNumSends(track, 0), however, still
+		// returns only the number of real sends. We therefore walk the index space,
+		// identifying hardware outputs by their lack of a destination track and
+		// skipping them (they are enumerated separately as category 1 below) until we
+		// have found every real send. We deliberately don't rely on the relative
+		// order of hardware outputs and sends. On REAPER versions before 7.75,
+		// category 0 contains no hardware outputs, so this behaves like a simple
+		// 0..count iteration.
 		int maxIndex = count;
 		if constexpr (category == 0) {
 			maxIndex += GetTrackNumSends(track, 1);

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -1583,34 +1583,31 @@ class TrackParams: public ReaperObjParamSource {
 	template<int category>
 	void addSendParams(const char* trackParam) {
 		int count = GetTrackNumSends(track, category);
-		// Since REAPER 7.75, the category 0 (sends) index space used by
-		// GetSetTrackSendInfo also includes hardware outputs; the routing UI orders
-		// these before the real sends. GetTrackNumSends(track, 0), however, still
-		// returns only the number of real sends. We therefore walk the index space,
-		// identifying hardware outputs by their lack of a destination track and
-		// skipping them (they are enumerated separately as category 1 below) until we
-		// have found every real send. We deliberately don't rely on the relative
-		// order of hardware outputs and sends. On REAPER versions before 7.75,
-		// category 0 contains no hardware outputs, so this behaves like a simple
-		// 0..count iteration.
-		int maxIndex = count;
+		int i = 0;
 		if constexpr (category == 0) {
-			maxIndex += GetTrackNumSends(track, 1);
+			// Since REAPER 7.75, the category 0 (sends) index space used by
+			// GetSetTrackSendInfo also includes hardware outputs, which the routing UI
+			// orders before the real sends. GetTrackNumSends(track, 0), however, still
+			// returns only the number of real sends. If the first entry is a hardware
+			// output (it has no destination track), skip past the hardware outputs so
+			// we enumerate only real sends; they are enumerated separately as category 1
+			// by a subsequent call to this function. On REAPER versions before 7.75,
+			// category 0 contains no hardware outputs, so this behaves like a simple
+			// 0..count iteration.
+			const int hwCount = GetTrackNumSends(track, 1);
+			if (hwCount > 0 &&
+					!GetSetTrackSendInfo(this->track, category, 0, trackParam, nullptr)) {
+				i += hwCount;
+				count += hwCount;
+			}
 		}
 		string lastTarget;
 		int sameTargetCount = 1;
-		for (int i = 0, found = 0; i < maxIndex && found < count; ++i) {
+		for (; i < count; ++i) {
 			string target;
 			if (trackParam) {
 				// Send or receive.
 				MediaTrack* sendTrack = (MediaTrack*)GetSetTrackSendInfo(this->track, category, i, trackParam, nullptr);
-				if constexpr (category == 0) {
-					if (!sendTrack) {
-						// A hardware output occupying a slot in the sends index space.
-						// Skip it here; it is enumerated as a hardware output below.
-						continue;
-					}
-				}
 				auto trackNum = (int)(size_t)GetSetMediaTrackInfo(sendTrack,
 					"IP_TRACKNUMBER", nullptr);
 				char* trackName = (char*)GetSetMediaTrackInfo(sendTrack, "P_NAME", nullptr);
@@ -1722,7 +1719,6 @@ class TrackParams: public ReaperObjParamSource {
 			this->params.push_back(make_unique<TrackSendParamProvider>(
 				paramName(translate("send type")), this->track, category, i, "I_SENDMODE",
 				SendTypeParam::make));
-			++found;
 		}
 	}
 

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -1435,6 +1435,11 @@ class AudioChannelParam:  public ReaperObjParam {
 	private:
 	Param::AfterOption addChannels(int count) {
 		MediaTrack* track = this->getTargetTrack();
+		if (!track) {
+			// No target track (e.g. a hardware output, or a send REAPER reports with
+			// no destination track). There's nothing to add channels to.
+			return Param::AfterOption::nothing;
+		}
 		int channels = *(int*)GetSetMediaTrackInfo(track, "I_NCHAN", nullptr);
 		channels += count;
 		GetSetMediaTrackInfo(track, "I_NCHAN", (void*)&channels);
@@ -1448,6 +1453,21 @@ class SourceAudioChannelParam: public AudioChannelParam {
 			AudioChannelParam(provider) {
 		options.push_back({translate_ctxt("audio channel", "none"), -1});
 		MediaTrack* srcTrack = this->getTargetTrack();
+		if (!srcTrack) {
+			// No source track. We don't know how many source channels there are, so
+			// just expose the current setting alongside "none".
+			int src = *(int*)provider.getSetValue(nullptr);
+			if (src != -1) {
+				if (src & MONO_FLAG) {
+					this->options.push_back({fmt::format("{}", (src & ~MONO_FLAG) + 1), src});
+				} else {
+					// Multi-channel, but we don't know how many.
+					this->options.push_back({fmt::format("{}-", src + 1), src});
+				}
+			}
+			this->finishOptions();
+			return;
+		}
 		int channels = *(int*)GetSetMediaTrackInfo(srcTrack, "I_NCHAN", nullptr);
 		this->addMonoOptions(channels);
 		this->addStereoOptions(channels);
@@ -1473,7 +1493,6 @@ class DestAudioChannelParam:  public AudioChannelParam {
 	DestAudioChannelParam(ReaperObjParamProvider& provider ):
 			AudioChannelParam(provider) {
 		MediaTrack* dstTrack = this->getTargetTrack();
-		int trackChans = *(int*)GetSetMediaTrackInfo(dstTrack, "I_NCHAN", nullptr);
 		auto& sendProv = static_cast<TrackSendParamProvider&>(provider);
 		int srcChans = *(int*)sendProv.getSetValue("I_SRCCHAN", nullptr) >> 10;
 		if (srcChans == 0) {
@@ -1481,9 +1500,11 @@ class DestAudioChannelParam:  public AudioChannelParam {
 		} else if (srcChans > 1) {
 			srcChans *= 2;
 		}
-		if (srcChans == -1) {
-			// If no source audio channel is set, we don't know how many destination
-			// channels there are. Just expose the current setting.
+		if (!dstTrack || srcChans == -1) {
+			// If there's no destination track (e.g. a hardware output, or a send
+			// REAPER reports with no destination track), or no source audio channel
+			// is set, we don't know how many destination channels there are. Just
+			// expose the current setting.
 			int dest = *(int*)provider.getSetValue(nullptr);
 			if (dest & MONO_FLAG) {
 				this->options.push_back({fmt::format("{}", (dest & ~MONO_FLAG) + 1), dest});
@@ -1494,6 +1515,7 @@ class DestAudioChannelParam:  public AudioChannelParam {
 			this->max = 0;
 			return;
 		}
+		int trackChans = *(int*)GetSetMediaTrackInfo(dstTrack, "I_NCHAN", nullptr);
 		// Destination only supports stereo if the source is mono or stereo.
 		if (srcChans <= 2) {
 			this->addStereoOptions(trackChans);


### PR DESCRIPTION
Since REAPER 7.75 ("extend various TrackSend APIs to allow accessing 
sends/hardware outputs with UI ordering"), the category 0 (sends) index 
space used by GetSetTrackSendInfo includes hardware outputs, ordered 
before the real sends to match the routing UI. GetTrackNumSends(track, 0), 
however, still returns only the number of real sends. 
blank
OSARA's Track Parameters dialog iterated that index space as 0..sendCount, 
so as soon as a track had a hardware output, OSARA read hardware-output 
slots where it expected sends. Those slots have no destination track, so 
sends were mislabelled (e.g. "0 send volume" instead of "2 send volume"), 
and selecting the destination audio channel parameter passed a null 
destination track to GetSetMediaTrackInfo, crashing REAPER. This was not 
reproducible without a hardware output present, or before 7.75. 
blank
Now we walk the combined category 0 index space (bounded by sends + hardware 
outputs), skip entries with no destination track since those are hardware 
outputs already enumerated separately, and add each real send at its true 
index. On REAPER versions before 7.75, and on tracks with no hardware 
outputs, no entries are skipped and the loop behaves exactly as before, so 
there is no behaviour change there.

I've verified this is stable and consistent on REAPER 7.74, 7.75 and 7.76.

Fixes #1413 