### PR TITLE
Make paste/duplicate track and item added messages fully translatable

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4196,7 +4196,7 @@ void cmdPaste(int command) {
 	Main_OnCommand(command, 0);
 	int added;
 	// We want to report both tracks and items if both got added. Each part is
-	// a full, independently translatable phrase (e.g. "1 track added, 3 items
+	// a full, independently translatable phrase (e.g. "1 track added", "3 items
 	// added") because concatenating counted nouns doesn't work for languages
 	// with grammatical gender or complex plural forms; see #1410.
 	ostringstream s;

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -4195,27 +4195,25 @@ void cmdPaste(int command) {
 	}
 	Main_OnCommand(command, 0);
 	int added;
-	// We want to report both tracks and items if both got added; e.g.
-	// "1 track 2 items added".
+	// We want to report both tracks and items if both got added. Each part is
+	// a full, independently translatable phrase (e.g. "1 track added, 3 items
+	// added") because concatenating counted nouns doesn't work for languages
+	// with grammatical gender or complex plural forms; see #1410.
 	ostringstream s;
 	if ((added = CountTracks(0) - oldTracks) > 0) {
-		// Translators: Reported when tracks are added. Other things might be added
-		// at the same time (e.g. items), so other messages may surround this.
-		// {} will be replaced with the number of tracks; e.g. "2 tracks".
-		s << format(translate_plural("{} track", "{} tracks", added), added);
+		// Translators: Reported when tracks are added. {} will be replaced with
+		// the number of tracks; e.g. "2 tracks added".
+		s << format(translate_plural("{} track added", "{} tracks added", added), added);
 	}
 	if ((added = CountMediaItems(0) - oldItems) > 0) {
 		if (s.tellp() > 0) {
-			s << " ";
+			s << ", ";
 		}
-		// Translators: Reported when items are added. Other things might be added
-		// at the same time (e.g. tracks), so other messages may surround this.
-		// {} will be replaced with the number of items; e.g. "2 items".
-		s << format(translate_plural("{} item", "{} items", added), added);
+		// Translators: Reported when items are added. {} will be replaced with
+		// the number of items; e.g. "2 items added".
+		s << format(translate_plural("{} item added", "{} items added", added), added);
 	}
 	if (s.tellp() > 0) {
-		// Translators: Reported after the number of tracks and/or items added.
-		s << " " << translate("added");
 		maybeAddRippleMessage(s, command);
 		outputMessage(s);
 		return;


### PR DESCRIPTION
Fixes #1410.

When pasting/duplicating produces both new tracks and new items, `cmdPaste` built the message by gluing together two bare counted phrases ("2 tracks" + "3 items") and then tacking a single shared "added" on the end. As ElCrackLoko pointed out in the issue, that doesn't work for languages with grammatical gender (Spanish "agregado"/"agregada" can't agree with both a masculine and a feminine noun in the same word) or more complex plural systems.

This applies the fix James and Scott settled on in the thread: each part becomes its own complete, translatable phrase ("2 tracks added", "3 items added"), joined with ", " when both are present. So in English you now get "1 track added, 3 items added" instead of "1 track 3 items added". This is the same join pattern already used for the combined mute/solo/arm/phase messages elsewhere in this file, so it should translate the same way those do.

Only touches `cmdPaste` - the automation item/envelope point/take branches further down and `cmdSplitItems` (which only ever reports items, never tracks) weren't affected by this bug and are untouched.

I don't have the Reaper SDK or the build submodules set up, so I wasn't able to actually compile this. I checked it carefully against the existing patterns in the file (the mute/solo/arm code does exactly this two-phrase-joined-by-comma thing already) and it only touches string literals and one separator character, but a build/smoke test on your end would be good before merging.
