### PR TITLE
Don't report an uninitialised value when trying to move to prev/next …

### DIFF
--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -1976,9 +1976,10 @@ void postMoveToTimeSig(int command) {
 	int marker = FindTempoTimeSigMarker(0, cursor + 0.0001);
 	double pos, bpm;
 	int sigNum, sigDenom;
-	GetTempoTimeSigMarker(0, marker, &pos, nullptr, nullptr, &bpm, &sigNum, &sigDenom, nullptr);
-	if (pos != cursor)
+	if (!GetTempoTimeSigMarker(0, marker, &pos, nullptr, nullptr, &bpm, &sigNum,
+		&sigDenom, nullptr) || pos != cursor) {
 		return;
+	}
 	fakeFocus = FOCUS_TIMESIG;
 	ostringstream s;
 	// Translators: Reported when moving to a tempo change. {} will be replaced


### PR DESCRIPTION
…tempo marker in projects where no tempo markers exist