### PR TITLE
Mac: look up translations for messages which contain an access key

### DIFF
--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -5,9 +5,11 @@
  * License: GNU General Public License version 2.0
  */
 
+#include <algorithm>
 #include <string>
 #include <fstream>
 #include <map>
+#include <vector>
 #include <tinygettext/dictionary.hpp>
 #include <tinygettext/po_parser.hpp>
 #include "osara.h"
@@ -65,6 +67,51 @@ static istringstream filterPoAmpersands(istream& input) {
 	}
 	return istringstream(filtered);
 }
+
+static string stripAmpersands(string text) {
+	text.erase(remove(text.begin(), text.end(), '&'), text.end());
+	return text;
+}
+
+static vector<string> stripAmpersands(const vector<string>& texts) {
+	vector<string> stripped;
+	stripped.reserve(texts.size());
+	for (const string& text: texts) {
+		stripped.push_back(stripAmpersands(text));
+	}
+	return stripped;
+}
+
+// filterPoAmpersands strips ampersands from msgids as well as translations.
+// translateDialog needs that, since GetWindowText returns text which SWELL has
+// already stripped. However, it also means a message containing an ampersand
+// in the source code can never match the dictionary; e.g. the items OSARA adds
+// to the Extensions menu. Parse the file a second time without the filter and
+// add those original msgids as extra keys for the stripped translations, so
+// both forms of a message can be looked up.
+static void addUnstrippedMsgids(const string& path) {
+	ifstream input(path);
+	tinygettext::Dictionary unstripped;
+	tinygettext::POParser::parse(path, input, unstripped);
+	// Note that tinygettext never stores the plural msgid; it only uses it in
+	// log messages. That's why we pass msgid for it below.
+	unstripped.foreach([](const string& msgid, vector<string>& msgstrs) {
+		if (msgid.find('&') == string::npos) {
+			return;
+		}
+		translationDict.add_translation(msgid, msgid, stripAmpersands(msgstrs));
+	});
+	unstripped.foreach_ctxt([](const string& ctxt, const string& msgid,
+			vector<string>& msgstrs) {
+		if (msgid.find('&') == string::npos) {
+			return;
+		}
+		// The context is looked up in its stripped form, since that's what
+		// filterPoAmpersands produced and what translateDialog passes.
+		translationDict.add_translation(stripAmpersands(ctxt), msgid, msgid,
+			stripAmpersands(msgstrs));
+	});
+}
 #endif
 
 void initTranslation() {
@@ -108,6 +155,7 @@ void initTranslation() {
 	ifstream input(path);
 	istringstream filteredInput = filterPoAmpersands(input);
 	tinygettext::POParser::parse(path, filteredInput, translationDict);
+	addUnstrippedMsgids(path);
 #endif
 }
 


### PR DESCRIPTION
Follow-up to #1354 (issue #1352). That change strips "&" out of every string in the po file when OSARA loads it on Mac, msgids included. The dialog path needs that, because GetWindowText hands back text SWELL has already stripped. The side effect is that a msgid containing an access key no longer exists in the dictionary, so a lookup written as a C++ literal can never match it. Those messages stay English on Mac even when the po has a translation. Affected: the OSARA items in the Extensions menu, the loudness context menu, "Show/hide &envelope" and the channel entries in paramsUi, and the 13 setting names config.cpp turns into toggle action names. 25 call sites, 24 distinct messages.

The fix parses the po a second time without the filter and adds each original msgid as an extra key for the same stripped translation. It is additive: every entry the old code produced keeps its value, the dialog path still resolves on the stripped keys, and translate/translate_ctxt/translate_plural keep their current signatures. All of it lives inside the existing `#ifndef _WIN32` block, so the Windows path does not run any of it.

The extension does not build on Linux, so I checked this with a host test program. It compiles filterPoAmpersands and the new addUnstrippedMsgids straight out of src/translation.cpp, includes the real src/translation.h, links against the vendored tinygettext, and then runs the 24 affected lookups over a shipped po the way initTranslation does on Mac. On master, with locale/zh_CN.po (three of the 24 result lines):

```
MISS       translate("Online &documentation") -> "Online &documentation"
MISS       translate("Check for &update") -> "Check for &update"
MISS       translate_ctxt(config, "Report &position when navigating events in MIDI editor") -> "Report &position when navigating events in MIDI editor"
checked 24 lookups: 24 missed, 0 wrong, 0 untranslated
dialog path: 0 missed
entries changed vs master: 0
FAIL
```

With this change, the same three lines:

```
TRANSLATED translate("Online &documentation") -> "在线文档(D)"
TRANSLATED translate("Check for &update") -> "检查更新(u)"
TRANSLATED translate_ctxt(config, "Report &position when navigating events in MIDI editor") -> "在MIDI编辑器中朗读浏览事件的位置(P)"
checked 24 lookups: 0 missed, 0 wrong, 0 untranslated
dialog path: 0 missed
entries changed vs master: 0
PASS
```

"dialog path" repeats the config lookups with the ampersands already removed, which is what translateWindow passes. "entries changed vs master" walks every entry of a dictionary built the old way and compares it against the new one, so a non-zero count there means something that used to translate now translates differently. Run over all 11 shipped po files, the change turns every miss into a hit and moves nothing else. Where a po has no translation for a message the test reports it untranslated and skips it, so tr_TR is the one file that already passes on master: it translates none of the 24 yet.

That test also compiles copies of the call sites that use a translate result as a C string, whether by assignment (gaccel_register_t::desc, custom_action_register_t::name), by cast (MENUITEMINFO::dwTypeData) or as a `const char*` argument (reviewMessage, MessageBox). A change to those return types would break its build. Both g++ 16.1.1 and clang 22.1.8 build it and it passes. Separately, src/translation.cpp itself passes `-fsyntax-only -std=c++20 -Wall` under both compilers against the SWELL headers, with no new warnings. Running site_scons/makePot.py over src/\*.cpp and src/\*.rc before and after gives a byte identical pot.

The cost is one extra parse of the po at startup on Mac plus a temporary second dictionary for the length of the call. zh_CN.po is 97 KB and one parse measures around 4 ms here.

I have no Mac, so none of the above is a run of the real extension. Could someone smoke test the Extensions menu and the OSARA settings under a translated language pack before this merges? Thanks.
