### PR TITLE
Make the decimal point translatable.

### DIFF
--- a/src/controlSurface.cpp
+++ b/src/controlSurface.cpp
@@ -136,8 +136,7 @@ class Surface: public IReaperControlSurface {
 			s << translate("volume") << " ";
 			this->lastParam = PARAM_VOLUME;
 		}
-		s << fixed << setprecision(2);
-		s << VAL2DB(volume);
+		s << formatDouble(VAL2DB(volume), 2);
 		outputMessage(s);
 	}
 

--- a/src/osara.h
+++ b/src/osara.h
@@ -350,7 +350,13 @@ const char* getActionName(int command, KbdSectionInfo* section=nullptr, bool ski
 
 bool isTrackSelected(MediaTrack* track);
 bool isTrackArmed(MediaTrack* track);
-std::string formatDouble(double d, int precision, bool plus=false);
+
+// Format a double d to precision decimal places.
+// If plus is true, a "+" prefix will be included for a positive number.
+// If stripZeros is true, trailing zeroes will be removed.
+std::string formatDouble(double d, int precision, bool plus=false,
+	bool stripZeros=true);
+
 MediaItem* getItemWithFocus();
 
 #ifdef _WIN32

--- a/src/paramsUi.cpp
+++ b/src/paramsUi.cpp
@@ -321,9 +321,7 @@ class ParamsDialog {
 			// Fall back to a percentage.
 			double percent = (this->val - this->param->min)
 				/ (this->param->max - this->param->min) * 100;
-			ostringstream s;
-			s << fixed << setprecision(1) << percent << "%";
-			this->valText = s.str();
+			this->valText = formatDouble(percent, 1) + "%";
 		}
 #ifdef _WIN32
 		// Set the slider's accessible value to this text.

--- a/src/peakWatcher.cpp
+++ b/src/peakWatcher.cpp
@@ -395,7 +395,6 @@ bool isWatchingMultipleValues() {
 
 void CALLBACK tick(HWND hwnd, UINT msg, UINT_PTR event, DWORD time) {
 	ostringstream s;
-	s << fixed << setprecision(1);
 	const bool multiple = isWatchingMultipleValues();
 	auto& projWatchers = watchers[currentProject()];
 	for (int w = 0; w < NUM_WATCHERS; ++w) {
@@ -451,7 +450,7 @@ void CALLBACK tick(HWND hwnd, UINT msg, UINT_PTR event, DWORD time) {
 					if (levelType.separateChannels) {
 						s << translate(CHANNEL_NAMES[c]) << " ";
 					}
-					s << newPeak;
+					s << formatDouble(newPeak, 1);
 					outputMessage(s);
 				}
 			}
@@ -718,8 +717,7 @@ void report(int watcherIndex, int channel) {
 		return;
 	}
 	ostringstream s;
-	s << fixed << setprecision(1);
-	s << watcher.channels[channel].peak;
+	s << formatDouble(watcher.channels[channel].peak, 1);
 	outputMessage(s);
 }
 

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -267,16 +267,16 @@ string formatTimeMinsec(double time, bool useCache) {
 		s << format(translate("{} min"), minute) << " ";
 		oldMinute = minute;
 	}
-	// Translators: Used when reporting a time in seconds. {:.3f} will be
-	// replaced with the number of seconds; e.g. "2 sec".
-	s << format(translate("{:#.3f} sec"), time);
+	// Translators: Used when reporting a time in seconds. {} will be replaced
+	// with the number of seconds; e.g. "2 sec".
+	s << format(translate("{} sec"), formatDouble(time, 3, false, false));
 	return s.str();
 }
 
 string formatTimeSec (double time) {
-	// Translators: Used when reporting a time in seconds. {:.3f} will be
-	// replaced with the number of seconds; e.g. "2 sec".
-	return format(translate("{:.3f} sec"), time);
+	// Translators: Used when reporting a time in seconds. {} will be replaced
+	// with the number of seconds; e.g. "2 sec".
+	return format(translate("{} sec"), formatDouble(time, 3, false, false));
 }
 
 string formatTimeRoundSec (double time) {
@@ -860,20 +860,24 @@ bool isTrackGrouped(MediaTrack* track) {
 	return false;
 }
 
-// Format a double d to precision decimal places, stripping trailing zeroes.
-// If plus is true, a "+" prefix will be included for a positive number.
-string formatDouble(double d, int precision, bool plus) {
+string formatDouble(double d, int precision, bool plus, bool stripZeros) {
 	string s = format(plus ? "{:+.{}f}" : "{:.{}f}", d, precision);
-	size_t pos = s.find_last_not_of("0");
-	if(s[pos] == '.') {
-		// also strip the trailing decimal point
-		pos -= 1;
+	if (stripZeros) {
+		size_t pos = s.find_last_not_of("0");
+		if (pos == string::npos) {
+			s = "0";
+		} else if (s[pos] == '.') {
+			// also strip the trailing decimal point
+			pos -= 1;
+			s = s.substr(0, pos + 1);
+		} else {
+			s = s.substr(0, pos + 1);
+		}
+		if (s == "+0" || s == "-0") {
+			s = "0";
+		}
 	}
-	auto stripped = s.substr(0, pos + 1);
-	if(stripped == "+0" || stripped == "-0") {
-		return "0";
-	}
-	return stripped;
+	return s;
 }
 
 string gridDivisionToFriendlyName(double division) {
@@ -1812,13 +1816,13 @@ void formatPan(double pan, ostringstream& output) {
 		// Translators: Panned to the center.
 		output << translate("center");
 	} else if (pan < 0) {
-		// Translators: Panned to the left. {:g} will be replaced with the amount;
+		// Translators: Panned to the left. {} will be replaced with the amount;
 		// e.g. "20% left".
-		output << format(translate("{:g}% left"), -pan);
+		output << format(translate("{}% left"), formatDouble(-pan, 2));
 	} else {
-		// Translators: Panned to the right. {:g} will be replaced with the amount;
+		// Translators: Panned to the right. {} will be replaced with the amount;
 		// e.g. "20% right".
-		output << format(translate("{:g}% right"), pan);
+		output << format(translate("{}% right"), formatDouble(pan, 2));
 	}
 }
 
@@ -2620,18 +2624,18 @@ void postToggleTrackSoloDefeat(int command) {
 void postChangeTransientDetectionSensitivity(int command) {
 	double sensitivity = *(double*)get_config_var("transientsensitivity",
 		nullptr) * 100;
-		// Translators: report transient sensitivity. {:g} is replaced with the sensitivity percentage;
+		// Translators: report transient sensitivity. {} is replaced with the sensitivity percentage;
 		// E.g. "13% sensitivity"
 	outputMessage(format(
-		translate("{:g}% sensitivity"), sensitivity));
+		translate("{}% sensitivity"), formatDouble(sensitivity, 2)));
 }
 
 void postChangeTransientDetectionThreshold(int command) {
 	double threshold = *(double*)get_config_var("transientthreshold",
 		nullptr);
 	// Translators: Reported when changing the transient detection threshold.
-	// {:g} will be replaced with the threshold; e.g. "{} dB threshold".
-	outputMessage(format(translate("{:g} dB threshold"), threshold));
+	// {} will be replaced with the threshold; e.g. "{} dB threshold".
+	outputMessage(format(translate("{} dB threshold"), formatDouble(threshold, 2)));
 }
 
 void postToggleEnvelopePointsMoveWithMediaItems(int command) {
@@ -5395,10 +5399,7 @@ void cmdMoveStretch(int command) {
 }
 
 void reportPeak(MediaTrack* track, int channel) {
-	ostringstream s;
-	s << fixed << setprecision(1);
-	s << VAL2DB(Track_GetPeakInfo(track, channel));
-	outputMessage(s);
+	outputMessage(formatDouble(VAL2DB(Track_GetPeakInfo(track, channel)), 1));
 }
 
 void cmdReportPeakCurrentC1(int command) {

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -877,6 +877,15 @@ string formatDouble(double d, int precision, bool plus, bool stripZeros) {
 			s = "0";
 		}
 	}
+	// Translators: The decimal point symbol.
+	const string decimal = translate_ctxt("decimal", ".");
+	if (decimal == ".") {
+		return s;
+	}
+	const auto decimalPos = s.find('.');
+	if (decimalPos != string::npos) {
+		s.replace(decimalPos, 1, decimal);
+	}
 	return s;
 }
 


### PR DESCRIPTION
In English, the decimal point is ".". However, in some other languages, the decimal point is different; e.g. "," in German. Using the incorrect decimal point can cause confusing pronunciation of numbers. To deal with this, make the decimal point translatable. Note that REAPER itself still always uses the English decimal point. Therefore, any values that are formatted by REAPER or which might be passed to REAPER later still use the English decimal point; e.g. the text box in the Parameters dialog.
Fixes #1438.